### PR TITLE
feat(mindmap):#EV-242 add button for mindmap on toolbar and add shared mindmaps in folders

### DIFF
--- a/src/main/java/net/atos/entng/mindmap/Mindmap.java
+++ b/src/main/java/net/atos/entng/mindmap/Mindmap.java
@@ -65,8 +65,6 @@ public class Mindmap extends BaseServer {
         MongoDbConf conf = MongoDbConf.getInstance();
         conf.setCollection(MINDMAP_COLLECTION);
 
-        MongoDbConf confFolder = MongoDbConf.getInstance();
-        confFolder.setCollection(FOLDER_COLLECTION);
 
         setDefaultResourceFilter(new ShareAndOwner());
         if (config.getBoolean("searching-event", true)) {

--- a/src/main/java/net/atos/entng/mindmap/controllers/FolderController.java
+++ b/src/main/java/net/atos/entng/mindmap/controllers/FolderController.java
@@ -38,18 +38,18 @@ public class FolderController extends MongoDbControllerHelper {
     }
 
 
-    @Get("/folders/:id/children/:isShare/:isMine")
+    @Get("/folders/:id/children/share/:isShare/mine/:isMine")
     @ApiDoc("Get all folders and mindmaps")
     @SuppressWarnings("unchecked")
     public void getFolderChildren(HttpServerRequest request) {
 
         String id = request.getParam(Field.ID);
-        String isShare = request.getParam(Field.IS_SHARE);
-        String isMine = request.getParam(Field.IS_MINE);
+        Boolean isSHareBool = Boolean.parseBoolean(request.getParam(Field.IS_SHARE));
+        Boolean isMineBool =  Boolean.parseBoolean(request.getParam(Field.IS_MINE));
 
         UserUtils.getUserInfos(this.eb, request, user -> {
             Future<JsonArray> folders = folderService.getFoldersChildren(id, user, false);
-            Future<JsonArray> mindmaps = mindmapService.listMindmap(id, user, isShare,isMine);
+            Future<JsonArray> mindmaps = mindmapService.listMindmap(id, user, isSHareBool, isMineBool);
             CompositeFuture.all(mindmaps, folders).onSuccess(res -> {
                                 ((List<JsonObject>) mindmaps.result().getList()).forEach(mindmap -> {
                                     mindmap.put(Field.TYPE, Field.MINDMAP);

--- a/src/main/java/net/atos/entng/mindmap/controllers/FolderController.java
+++ b/src/main/java/net/atos/entng/mindmap/controllers/FolderController.java
@@ -44,12 +44,12 @@ public class FolderController extends MongoDbControllerHelper {
     public void getFolderChildren(HttpServerRequest request) {
 
         String id = request.getParam(Field.ID);
-        Boolean isSHareBool = Boolean.parseBoolean(request.getParam(Field.IS_SHARE));
-        Boolean isMineBool =  Boolean.parseBoolean(request.getParam(Field.IS_MINE));
+        Boolean isShare = Boolean.parseBoolean(request.getParam(Field.IS_SHARE));
+        Boolean isMine =  Boolean.parseBoolean(request.getParam(Field.IS_MINE));
 
         UserUtils.getUserInfos(this.eb, request, user -> {
             Future<JsonArray> folders = folderService.getFoldersChildren(id, user, false);
-            Future<JsonArray> mindmaps = mindmapService.listMindmap(id, user, isSHareBool, isMineBool);
+            Future<JsonArray> mindmaps = mindmapService.listMindmap(id, user, isShare, isMine);
             CompositeFuture.all(mindmaps, folders).onSuccess(res -> {
                                 ((List<JsonObject>) mindmaps.result().getList()).forEach(mindmap -> {
                                     mindmap.put(Field.TYPE, Field.MINDMAP);

--- a/src/main/java/net/atos/entng/mindmap/controllers/FolderController.java
+++ b/src/main/java/net/atos/entng/mindmap/controllers/FolderController.java
@@ -38,17 +38,18 @@ public class FolderController extends MongoDbControllerHelper {
     }
 
 
-    @Get("/folders/:id/children")
+    @Get("/folders/:id/children/:isShare/:isMine")
     @ApiDoc("Get all folders and mindmaps")
     @SuppressWarnings("unchecked")
     public void getFolderChildren(HttpServerRequest request) {
 
         String id = request.getParam(Field.ID);
-
+        String isShare = request.getParam(Field.IS_SHARE);
+        String isMine = request.getParam(Field.IS_MINE);
 
         UserUtils.getUserInfos(this.eb, request, user -> {
             Future<JsonArray> folders = folderService.getFoldersChildren(id, user, false);
-            Future<JsonArray> mindmaps = mindmapService.getChildren(id, user, false);
+            Future<JsonArray> mindmaps = mindmapService.listMindmap(id, user, isShare,isMine);
             CompositeFuture.all(mindmaps, folders).onSuccess(res -> {
                                 ((List<JsonObject>) mindmaps.result().getList()).forEach(mindmap -> {
                                     mindmap.put(Field.TYPE, Field.MINDMAP);

--- a/src/main/java/net/atos/entng/mindmap/controllers/MindmapController.java
+++ b/src/main/java/net/atos/entng/mindmap/controllers/MindmapController.java
@@ -149,7 +149,7 @@ public class MindmapController extends MongoDbControllerHelper {
         String id = request.getParam(Field.ID);
         UserUtils.getUserInfos(this.eb, request, user -> {
             RequestUtils.bodyToJson(request, pathPrefix + "mindmap", body -> {
-                mindmapService.removeMindmapUserId(id, user)
+                mindmapService.avoidDuplicatesUserId(id, user)
                         .compose(deleteMindmapRes -> mindmapService.updateMindmap(id, body, user))
                         .onFailure(error -> badRequest(request))
                         .onSuccess(result -> renderJson(request, result));

--- a/src/main/java/net/atos/entng/mindmap/controllers/MindmapController.java
+++ b/src/main/java/net/atos/entng/mindmap/controllers/MindmapController.java
@@ -150,7 +150,7 @@ public class MindmapController extends MongoDbControllerHelper {
         UserUtils.getUserInfos(this.eb, request, user -> {
             RequestUtils.bodyToJson(request, pathPrefix + "mindmap", body -> {
                 mindmapService.avoidDuplicatesUserId(id, user)
-                        .compose(deleteMindmapRes -> mindmapService.updateMindmap(id, body, user))
+                        .compose(deleteMindmapRes -> mindmapService.updateMindmapFolderParent(id, body, user))
                         .onFailure(error -> badRequest(request))
                         .onSuccess(result -> renderJson(request, result));
             });

--- a/src/main/java/net/atos/entng/mindmap/controllers/MindmapController.java
+++ b/src/main/java/net/atos/entng/mindmap/controllers/MindmapController.java
@@ -149,7 +149,7 @@ public class MindmapController extends MongoDbControllerHelper {
         String id = request.getParam(Field.ID);
         UserUtils.getUserInfos(this.eb, request, user -> {
             RequestUtils.bodyToJson(request, pathPrefix + "mindmap", body -> {
-                mindmapService.pullUpdateMindmap(id, user)
+                mindmapService.removeMindmapUserId(id, user)
                         .compose(deleteMindmapRes -> mindmapService.updateMindmap(id, body, user))
                         .onFailure(error -> badRequest(request))
                         .onSuccess(result -> renderJson(request, result));

--- a/src/main/java/net/atos/entng/mindmap/core/constants/Field.java
+++ b/src/main/java/net/atos/entng/mindmap/core/constants/Field.java
@@ -3,6 +3,8 @@ package net.atos.entng.mindmap.core.constants;
 public class Field {
 
     public static final String NULL = "null";
+    public static final String SHARED = "shared";
+    public static final String TRUE = "true";
 
     /***
      * FOLDER ET MINDMAP
@@ -17,6 +19,9 @@ public class Field {
     public static final String OWNER = "owner";
     public static final String USER_ID = "userId";
     public static final String DISPLAY_NAME = "displayName";
+    public static final String FOLDER_PARENT ="folder_parent";
+    public static final String GROUP_ID = "groupId";
+
 
     /***
      * FOLDER
@@ -30,6 +35,8 @@ public class Field {
      */
     public static final String MINDMAP = "MINDMAP";
     public static final String COLLECTION_MINDMAP = "mindmap";
+    public static final String IS_SHARE = "isShare";
+    public static final String IS_MINE = "isMine";
 
     /***
      * MONGO_DB
@@ -51,6 +58,10 @@ public class Field {
     public static final String PIPELINE = "pipeline";
     public static final String EXISTS = "exists";
     public static final String STATUS = "status";
+    public static final String OR = "or";
+    public static final String IN = "in";
+    public static final String NE = "ne";
+    public static final String AND = "and";
 
 
 }

--- a/src/main/java/net/atos/entng/mindmap/service/FolderService.java
+++ b/src/main/java/net/atos/entng/mindmap/service/FolderService.java
@@ -22,7 +22,7 @@ public interface FolderService {
 
     Future<JsonObject> deleteFolder(String id, UserInfos user);
 
-    void allFolderMindmap(String id, UserInfos user, boolean isInTrash, Handler<Either<String, JsonArray>> handler);
-
     Future<JsonObject> deleteFolderList(List<String> ids, UserInfos user);
+
+
 }

--- a/src/main/java/net/atos/entng/mindmap/service/MindmapService.java
+++ b/src/main/java/net/atos/entng/mindmap/service/MindmapService.java
@@ -55,7 +55,7 @@ public interface MindmapService {
 
     Future<JsonObject> updateMindmapFolder(List<String> ids, JsonObject body, UserInfos user);
 
-    Future<JsonObject> updateMindmap(String id, JsonObject body, UserInfos user);
+    Future<JsonObject> updateMindmapFolderParent(String id, JsonObject body, UserInfos user);
 
     Future<JsonObject> deleteMindmap(String id, UserInfos user);
 

--- a/src/main/java/net/atos/entng/mindmap/service/MindmapService.java
+++ b/src/main/java/net/atos/entng/mindmap/service/MindmapService.java
@@ -63,9 +63,9 @@ public interface MindmapService {
 
     Future<JsonArray> getTrashMindmap(UserInfos user);
 
-    Future<JsonArray> listMindmap(String mindmapFolderParentId, UserInfos user, String isShare, String isMine);
+    Future<JsonArray> listMindmap(String mindmapFolderParentId, UserInfos user, Boolean isShare, Boolean isMine);
 
-    Future<JsonObject> pullUpdateMindmap(String id, UserInfos user);
+    Future<JsonObject> removeMindmapUserId(String id, UserInfos user);
 
-    Future<JsonObject> updateMindmapShared(List<String> ids, UserInfos user);
+    Future<JsonObject> moveSharedMindmapToRootFolder(List<String> ids, UserInfos user);
 }

--- a/src/main/java/net/atos/entng/mindmap/service/MindmapService.java
+++ b/src/main/java/net/atos/entng/mindmap/service/MindmapService.java
@@ -19,12 +19,15 @@
 
 package net.atos.entng.mindmap.service;
 
+import fr.wseduc.webutils.Either;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.entcore.common.user.UserInfos;
 
+import javax.management.monitor.StringMonitor;
 import java.util.List;
 
 /**
@@ -50,8 +53,6 @@ public interface MindmapService {
      */
     void exportSVG(HttpServerRequest request, JsonObject message);
 
-    Future<JsonArray> getChildren(String id, UserInfos user, boolean isInTrash);
-
     Future<JsonObject> updateMindmapFolder(List<String> ids, JsonObject body, UserInfos user);
 
     Future<JsonObject> updateMindmap(String id, JsonObject body, UserInfos user);
@@ -62,4 +63,9 @@ public interface MindmapService {
 
     Future<JsonArray> getTrashMindmap(UserInfos user);
 
+    Future<JsonArray> listMindmap(String mindmapFolderParentId, UserInfos user, String isShare, String isMine);
+
+    Future<JsonObject> pullUpdateMindmap(String id, UserInfos user);
+
+    Future<JsonObject> updateMindmapShared(List<String> ids, UserInfos user);
 }

--- a/src/main/java/net/atos/entng/mindmap/service/MindmapService.java
+++ b/src/main/java/net/atos/entng/mindmap/service/MindmapService.java
@@ -65,7 +65,7 @@ public interface MindmapService {
 
     Future<JsonArray> listMindmap(String mindmapFolderParentId, UserInfos user, Boolean isShare, Boolean isMine);
 
-    Future<JsonObject> removeMindmapUserId(String id, UserInfos user);
+    Future<JsonObject> avoidDuplicatesUserId(String id, UserInfos user);
 
     Future<JsonObject> moveSharedMindmapToRootFolder(List<String> ids, UserInfos user);
 }

--- a/src/main/java/net/atos/entng/mindmap/service/impl/FolderServiceImpl.java
+++ b/src/main/java/net/atos/entng/mindmap/service/impl/FolderServiceImpl.java
@@ -158,12 +158,8 @@ public class FolderServiceImpl implements FolderService {
         query.put(String.format("%s.%s", Field.OWNER, Field.USER_ID)).is(user.getUserId());
 
         getNestedFolderChildrenIds(id)
-                .onFailure(err -> {
-                    String message = String.format("[Mindmap@%s::deleteFolder] Failed to get the folder : %s", this.getClass().getSimpleName(), err.getMessage());
-                    log.error(message + err);
-                    promise.fail(err.getMessage());
-                })
-                .onSuccess(nestedfolderChildrenResult -> MongoHelper.getResultCommand(nestedfolderChildrenResult)
+
+                .compose(nestedfolderChildrenResult -> MongoHelper.getResultCommand(nestedfolderChildrenResult)
                         .compose(commandResult -> {
                             if(commandResult.getJsonObject(0).isEmpty()){
                                 promise.fail("MongoDb command fail");
@@ -182,8 +178,6 @@ public class FolderServiceImpl implements FolderService {
 
                         })
                         .onSuccess(resDelete -> mongoDb.delete(Field.COLLECTION_MINDMAP_FOLDER, MongoQueryBuilder.build(query), MongoDbResult.validResultHandler(PromiseHelper.handlerJsonObject(promise)))));
-
-
         return promise.future();
     }
 

--- a/src/main/java/net/atos/entng/mindmap/service/impl/MindmapServiceImpl.java
+++ b/src/main/java/net/atos/entng/mindmap/service/impl/MindmapServiceImpl.java
@@ -198,7 +198,7 @@ public class MindmapServiceImpl implements MindmapService {
     }
 
     @Override
-    public Future<JsonObject> updateMindmap(String id, JsonObject body, UserInfos user) {
+    public Future<JsonObject> updateMindmapFolderParent(String id, JsonObject body, UserInfos user) {
         Promise<JsonObject> promise = Promise.promise();
         QueryBuilder query = QueryBuilder.start(Field._ID).is(id);
         MongoUpdateBuilder modifier = new MongoUpdateBuilder();

--- a/src/main/java/net/atos/entng/mindmap/service/impl/MindmapServiceImpl.java
+++ b/src/main/java/net/atos/entng/mindmap/service/impl/MindmapServiceImpl.java
@@ -116,18 +116,18 @@ public class MindmapServiceImpl implements MindmapService {
                 new JsonObject().put(String.format("$%s", Field.IN), user.getGroupsIds()));
         JsonObject query = new JsonObject();
         JsonArray json = new JsonArray();
-        if (isShare.equals(Boolean.TRUE)) {
+        if (Boolean.TRUE.equals(isShare)) {
             json.add(isSharedMindmap);
             json.add(sharedContainsUserGroupIds);
         }
-        if (isMine.equals(Boolean.TRUE)) {
+        if (Boolean.TRUE.equals(isMine)) {
             json.add(userIsMdindOwner);
         }
 
         query.put(String.format("$%s", Field.OR), json);
 
         JsonObject queryResult = new JsonObject();
-        if (mindmapFolderParentId.equals(Field.NULL)) {
+        if (Field.NULL.equals(mindmapFolderParentId)) {
             JsonObject folderParentIsNull = new JsonObject().putNull(String.format("%s.%s", Field.FOLDER_PARENT, Field.FOLDER_PARENT_ID));
             JsonObject folderParentIsEmpty = new JsonObject().put(String.format("%s.%s", Field.FOLDER_PARENT, Field.FOLDER_PARENT_ID), new JsonObject().put(String.format("$%s", Field.EXISTS), false));
             JsonObject folderParentUserIdNotExist = new JsonObject().put(String.format("%s.%s", Field.FOLDER_PARENT, Field.USER_ID), new JsonObject().put(String.format("$%s", Field.NE), user.getUserId()));
@@ -185,7 +185,7 @@ public class MindmapServiceImpl implements MindmapService {
     }
 
     @Override
-    public Future<JsonObject> removeMindmapUserId(String id, UserInfos user) {
+    public Future<JsonObject> avoidDuplicatesUserId(String id, UserInfos user) {
         Promise<JsonObject> promise = Promise.promise();
 
         JsonObject query = new JsonObject();

--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -22,6 +22,8 @@
   "mindmap.format.png": "Format PNG",
   "mindmap.format.svg": "Format SVG",
   "mindmap.or.page.notfound.or.unauthorized": "La carte mentale ou la page demandée n'existe pas, a été supprimée, ou vous n'avez pas les droits pour y accéder.",
+  "mindmap.checkbox.share": "Cartes mentales partagées avec moi",
+  "mindmap.checkbox.my": "Mes cartes mentales",
   "mindmap.folder.create": "Créer un dossier",
   "mindmap.folder.title": "Titre du dossier",
   "mindmap.folder.title.root": "Mes cartes mentales",

--- a/src/main/resources/jsonschema/mindmap.json
+++ b/src/main/resources/jsonschema/mindmap.json
@@ -18,8 +18,13 @@
         "thumbnail": {
             "type": "string"
         },
-        "folder_parent_id": {
-            "type": ["string", "null"]
+        "folder_parent": {
+            "userId" : {
+                "type": "string"
+            },
+            "folder_parent_id": {
+                "type": ["string","null"]
+            }
         },
      	"map": {
      		"type": "string"

--- a/src/main/resources/public/template/mindmap-create.html
+++ b/src/main/resources/public/template/mindmap-create.html
@@ -18,7 +18,7 @@
                     </div>
                 </div>
                 <div class="row">
-                    <button reset-guard="createMindmap(mindmap.name)" class="right-magnet" ng-disabled="form.$invalid">
+                    <button reset-guard="createMindmap(mindmap.name,mindmap.description)" class="right-magnet" ng-disabled="form.$invalid">
                         <i18n>save</i18n>
                     </button>
                     <input type="button" class="button right-magnet cancel" navigation-trigger="cancelMindmapEdit()" i18n-value="cancel">

--- a/src/main/resources/public/template/mindmap-list.html
+++ b/src/main/resources/public/template/mindmap-list.html
@@ -13,9 +13,19 @@
             </nav>
 
         </div>
+        <directive-label-share name="nameLabel"
+                               on-sort="sortMindmap"
+                               is-checked="isCheckedLabelMy">
+        </directive-label-share>
+
+        <directive-label-share name="nameLabelShare"
+                               on-sort="sortShare"
+                               is-checked="isCheckedLabelShare">
+        </directive-label-share>
+
 
         <directive-folder-list folders="folders.all"
-                               mindmaps-item="mindmapsItem.mindmapsAll"
+                               mindmaps-item="mindmapsItem.mindmapsRight"
                                on-folder-tree-root="folderTreeDirective"
                                on-open-folder="openFolderByView"
                                on-update-folder="updateFolder"
@@ -27,7 +37,11 @@
                                on-move-folder="moveFolder"
                                tree-move-folder="displayTreeMoveFolder"
                                on-move-mindmap="moveMindmap"
-                               selected-folders-id="selectedFoldersId">
+                               selected-folders-id="selectedFoldersId"
+                               on-edit-mindmap="editMindmap"
+                               on-share-mindmap="shareMindmap"
+                               on-print-png-mindmap="printPngMindmap"
+                               on-change-mindmap-folder="changeMindmapFolder">
         </directive-folder-list>
     </div>
 
@@ -82,43 +96,10 @@
     <!-- Allows to display the panel to manage share rights -->
     <div ng-if="display.showPanel">
         <lightbox show="display.showPanel" on-close="display.showPanel = false;">
-            <share-panel app-prefix="'mindmap'" resources="mindmap"></share-panel>
+            <share-panel app-prefix="'mindmap'" resources="mindmap" auto-close="true">
+            </share-panel>
         </lightbox>
     </div>
 </div>
-
-
-<section class="toggle-buttons" ng-class="{  hide: mindmaps.selection().length === 0}">
-    <div class="toggle">
-        <div class="row">
-            <resource-right name="manage" resource="mindmaps.selection()" class="cell">
-                <button ng-if="mindmaps.selection().length === 1"
-                        ng-click="editMindmap(mindmaps.selection()[0], $event)">
-                    <i18n>properties</i18n>
-                </button>
-            </resource-right>
-            <resource-right name="manage" resource="mindmaps.selection()" class="cell">
-                <button workflow="mindmap.publish" ng-if="mindmaps.selection().length === 1"
-                        library-resource="mindmaps.selection()[0]">
-                    <i18n>bpr.publish</i18n>
-                </button>
-            </resource-right>
-            <button ng-if="mindmaps.selection().length === 1"
-                    ng-click="printPngMindmap(mindmaps.selection()[0], $event)">
-                <i18n>print</i18n>
-            </button>
-            <resource-right name="manage" resource="mindmaps.selection()" class="cell">
-                <button ng-click="shareMindmap(mindmaps.selection(), $event)">
-                    <i18n>share</i18n>
-                </button>
-            </resource-right>
-            <resource-right name="manage" resource="mindmaps.selection()" class="cell">
-                <button ng-click="display.confirmDeleteMindmap = true">
-                    <i18n>remove</i18n>
-                </button>
-            </resource-right>
-        </div>
-    </div>
-</section>
 </section>
 

--- a/src/main/resources/public/template/mindmap-update.html
+++ b/src/main/resources/public/template/mindmap-update.html
@@ -1,0 +1,33 @@
+<article class="row" ng-if="!forceToClose">
+    <form name="form" guard-root>
+        <div class="rigid-grid row">
+            <div class="two cell clip height-two">
+                <div class="absolute" loading-panel="upload-mindmap-thumbnail">
+                    <image-select ng-model="mindmap.thumbnail" default="/img/illustrations/mindmap.svg"></image-select>
+                </div>
+            </div>
+            <div class="margin-two height-three">
+                <div class="twelve cell horizontal-spacing">
+                    <input type="text" ng-model="mindmap.name" class="twelve cell" i18n-placeholder="mindmap.name"
+                           required/>
+                    <div class="row">
+                        <hr class="row"/>
+                    </div>
+                    <textarea ng-model="mindmap.description" class="twelve cell" i18n-placeholder="mindmap.description"
+                              input-guard></textarea>
+                    <div class="row">
+                        <hr class="row"/>
+                    </div>
+                </div>
+                <div class="row">
+                    <button reset-guard="updateMindmapFromForm(mindmap._id,mindmap.name,mindmap.folder_parent_id,mindmap.description)"
+                            class="right-magnet" ng-disabled="form.$invalid">
+                        <i18n>save</i18n>
+                    </button>
+                    <input type="button" class="button right-magnet cancel" navigation-trigger="cancelMindmapEdit()"
+                           i18n-value="cancel">
+                </div>
+            </div>
+        </div>
+    </form>
+</article>

--- a/src/main/resources/public/ts/controllers/main.ts
+++ b/src/main/resources/public/ts/controllers/main.ts
@@ -45,38 +45,38 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
         $scope.selectedFoldersId = FOLDER_ITEM.ID_NULL;
         $scope.selectedFoldersIdMove = null;
         (window as any).LAZY_MODE = false;
-        $scope.nameLabel = FOLDER_ITEM.MY_MINDMAP;
-        $scope.nameLabelShare = FOLDER_ITEM.MINDMAP_SHARE;
-        $scope.isCheckedLabelMy = false;
-        $scope.isCheckedLabelShare = false;
+        $scope.nameLabel = idiom.translate('mindmap.checkbox.my')
+        $scope.nameLabelShare = idiom.translate('mindmap.checkbox.share')
+        $scope.isCheckedLabelMy = true;
+        $scope.isCheckedLabelShare = true;
         $scope.sortMindmap = async (isChecked: boolean): Promise<void> => {
-            if (isChecked == true && $scope.isCheckedLabelShare == true) {
-                $scope.isCheckedLabelShare = false;
+            if (!isChecked && !$scope.isCheckedLabelShare) {
+                $scope.isCheckedLabelShare = true;
             }
-            if (isChecked == true) {
-                $scope.isCheckedLabelMy = true;
-                await $scope.openFolderById($scope.selectedFoldersId, FOLDER_ITEM.FALSE_VALUE, FOLDER_ITEM.TRUE_VALUE);
-            } else {
+            if (!isChecked) {
                 $scope.isCheckedLabelMy = false;
-                await $scope.openFolderById($scope.selectedFoldersId, FOLDER_ITEM.FALSE_VALUE, FOLDER_ITEM.FALSE_VALUE);
+                await $scope.openFolderById($scope.selectedFoldersId, true, false);
+            } else {
+                $scope.isCheckedLabelMy = true;
+                await $scope.openFolderById($scope.selectedFoldersId, true, true);
             }
 
         }
         $scope.sortShare = async (isChecked: boolean): Promise<void> => {
-            if (isChecked == true && $scope.isCheckedLabelMy == true) {
-                $scope.isCheckedLabelMy = false;
+            if (!isChecked && !$scope.isCheckedLabelMy) {
+                $scope.isCheckedLabelMy = true;
             }
-            if (isChecked == true) {
-                $scope.isCheckedLabelShare = true;
-                await $scope.openFolderById($scope.selectedFoldersId, FOLDER_ITEM.TRUE_VALUE, FOLDER_ITEM.FALSE_VALUE);
-            } else {
+            if (!isChecked) {
                 $scope.isCheckedLabelShare = false;
-                await $scope.openFolderById($scope.selectedFoldersId, FOLDER_ITEM.FALSE_VALUE, FOLDER_ITEM.FALSE_VALUE);
+                await $scope.openFolderById($scope.selectedFoldersId, false, true);
+            } else {
+                $scope.isCheckedLabelShare = true;
+                await $scope.openFolderById($scope.selectedFoldersId, true, true);
             }
         }
 
-        $scope.setFolderChildrenMindmap = async (id: string, isShare: string, isMine: string): Promise<void> => {
-            let folder: FolderItem[] = await folderService.getFolderChildren(id, FOLDER_ITEM.FALSE_VALUE, FOLDER_ITEM.FALSE_VALUE);
+        $scope.setFolderChildrenMindmap = async (id: string, isShare: boolean, isMine: boolean): Promise<void> => {
+            let folder: FolderItem[] = await folderService.getFolderChildren(id, true, true);
             let mindmap: FolderItem[] = await folderService.getFolderChildren(id, isShare, isMine);
             $scope.folders = new Folders(folder, []);
             $scope.mindmapsItem = new Folders([], mindmap);
@@ -108,11 +108,11 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
 
         $scope.initFolder = async (): Promise<void> => {
             if ($scope.isCheckedLabelMy == true) {
-                await $scope.setFolderChildrenMindmap(FOLDER_ITEM.ID_NULL, FOLDER_ITEM.FALSE_VALUE, FOLDER_ITEM.TRUE_VALUE);
+                await $scope.setFolderChildrenMindmap(FOLDER_ITEM.ID_NULL, false, true);
             } else if ($scope.isCheckedLabelShare == true) {
-                await $scope.setFolderChildrenMindmap(FOLDER_ITEM.ID_NULL, FOLDER_ITEM.TRUE_VALUE, FOLDER_ITEM.FALSE_VALUE);
+                await $scope.setFolderChildrenMindmap(FOLDER_ITEM.ID_NULL, true, false);
             } else {
-                await $scope.setFolderChildrenMindmap(FOLDER_ITEM.ID_NULL, FOLDER_ITEM.FALSE_VALUE, FOLDER_ITEM.FALSE_VALUE);
+                await $scope.setFolderChildrenMindmap(FOLDER_ITEM.ID_NULL, false, false);
             }
 
             $scope.setFolderRoot();
@@ -153,14 +153,14 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
                     if (elem) {
                         let children: models.Element[] = elem.children;
                         if (children.length > 0 && !children[0]._id) {
-                            await $scope.IsShareOrNot(folder._id);
+                            await $scope.IsShare(folder._id);
 
                             elem.children = $scope.folders.mapToChildrenTrees();
                             //setFakeFolder is use for the folder never open before.
                             $scope.folders.setFakeFolder(elem.children);
                         } else {
                             $scope.folders.all = $scope.folders.mapFromChildrenTree(elem.children);
-                            await $scope.IsShareOrNot(folder._id);
+                            await $scope.IsShare(folder._id);
                         }
                         $scope.openOrCloseFolder(folder);
                         $scope.selectedFoldersId = folder._id;
@@ -205,13 +205,13 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
                     if (elemMove) {
                         let children: models.Element[] = elemMove.children;
                         if (children.length > 0 && !children[0]._id) {
-                            $scope.foldersRootMove.setFolders(await folderService.getFolderChildren(folder._id, FOLDER_ITEM.FALSE_VALUE, FOLDER_ITEM.FALSE_VALUE));
+                            $scope.foldersRootMove.setFolders(await folderService.getFolderChildren(folder._id, true, true));
                             $scope.foldersRootMove.setFilterFolder(idFolderSelect);
                             elemMove.children = $scope.foldersRootMove.mapToChildrenTrees();
                             $scope.foldersRootMove.setFakeFolder(elemMove.children);
                         } else {
                             $scope.foldersRootMove.all = $scope.foldersRootMove.mapFromChildrenTree(elemMove.children);
-                            $scope.foldersRootMove.setFolders(await folderService.getFolderChildren(folder._id, FOLDER_ITEM.FALSE_VALUE, FOLDER_ITEM.FALSE_VALUE));
+                            $scope.foldersRootMove.setFolders(await folderService.getFolderChildren(folder._id, true, true));
                             $scope.foldersRootMove.setFilterFolder(idFolderSelect);
                         }
                         $scope.openOrCloseFolderMove(folder);
@@ -235,8 +235,8 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
         $scope.moveMindmap = async function (id: string, name: string): Promise<void> {
             let mindmap: MindmapFolder;
             if ($scope.selectedFoldersIdMove == FOLDER_ITEM.ID_NULL || !$scope.selectedFoldersIdMove) {
-                let userId = FOLDER_ITEM.ID_NULL;
-                let folder_parent_id = FOLDER_ITEM.ID_NULL;
+                let userId: string = FOLDER_ITEM.ID_NULL;
+                let folder_parent_id: string = FOLDER_ITEM.ID_NULL;
                 let folder_parent = {userId, folder_parent_id}
                 mindmap = new MindmapFolder(name, folder_parent);
             } else {
@@ -270,16 +270,16 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
             }
         }
 
-        $scope.openFolderById = async function (id: string, share: string, isMine: string): Promise<void> {
+        $scope.openFolderById = async function (id: string, share: boolean, isMine: boolean): Promise<void> {
             template.open('mindmap', 'mindmap-list');
             $timeout(function () {
                 $('body').trigger('whereami.update');
             }, 100)
             if (!share) {
-                share = FOLDER_ITEM.FALSE_VALUE;
+                share = false;
             }
             if (!isMine) {
-                isMine = FOLDER_ITEM.FALSE_VALUE;
+                isMine = false;
             }
 
             $scope.setFolderItem = await folderService.getFolderChildren(id, share, isMine)
@@ -290,20 +290,20 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
             }
         };
 
-        $scope.IsShareOrNot = async (id: string): Promise<void> => {
-            if ($scope.isCheckedLabelMy == true) {
-                await $scope.openFolderById(id, FOLDER_ITEM.FALSE_VALUE, FOLDER_ITEM.TRUE_VALUE);
-            } else if ($scope.isCheckedLabelShare == true) {
-                await $scope.openFolderById(id, FOLDER_ITEM.TRUE_VALUE, FOLDER_ITEM.FALSE_VALUE);
+        $scope.IsShare = async (id: string): Promise<void> => {
+            if (!$scope.isCheckedLabelMy) {
+                await $scope.openFolderById(id, true, false);
+            } else if (!$scope.isCheckedLabelShare) {
+                await $scope.openFolderById(id, false, true);
             } else {
-                await $scope.openFolderById(id, FOLDER_ITEM.FALSE_VALUE, FOLDER_ITEM.FALSE_VALUE);
+                await $scope.openFolderById(id, true, true);
             }
         }
 
         $scope.reloadView = async (): Promise<void> => {
             $scope.openedFolderIds = [];
             $scope.selectedFoldersId = FOLDER_ITEM.ID_NULL;
-            await $scope.IsShareOrNot(FOLDER_ITEM.ID_NULL);
+            await $scope.IsShare(FOLDER_ITEM.ID_NULL);
 
             $scope.initFolder();
             $scope.$apply()
@@ -333,7 +333,7 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
                 await mindmapService.updateMindmap(id, mindmap);
                 toasts.confirm(idiom.translate('mindmap.update.done'));
                 template.open('mindmap', 'mindmap-list');
-                await $scope.IsShareOrNot($scope.selectedFoldersId);
+                await $scope.IsShare($scope.selectedFoldersId);
             } catch (e) {
                 toasts.warning(idiom.translate("mindmap.update.fail"));
                 throw(e);
@@ -345,7 +345,7 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
                 await mindmapService.changeMindmapFolder(id, mindmap);
                 toasts.confirm(idiom.translate('mindmap.update.done'));
                 template.open('mindmap', 'mindmap-list');
-                await $scope.IsShareOrNot($scope.selectedFoldersId);
+                await $scope.IsShare($scope.selectedFoldersId);
             } catch (e) {
                 toasts.warning(idiom.translate("mindmap.update.fail"));
                 throw (e)
@@ -388,7 +388,7 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
                 await mindmapService.deleteMindmap(id);
                 toasts.confirm(idiom.translate('mindmap.delete.done'));
                 template.open('mindmap', 'mindmap-list');
-                await $scope.IsShareOrNot($scope.selectedFoldersId);
+                await $scope.IsShare($scope.selectedFoldersId);
             } catch (e) {
                 toasts.warning(idiom.translate('mindmap.delete.fail'));
                 throw(e);
@@ -437,13 +437,12 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
 
             $scope.forceToClose = true;
             var mindmap: MindmapFolder;
-            if ($scope.selectedFoldersId == "null") {
+            if ($scope.selectedFoldersId == FOLDER_ITEM.ID_NULL) {
                 mindmap = new MindmapFolder(name);
             } else {
-                let userId = model.me.userId;
-                ;
-                let folder_parent_id = $scope.selectedFoldersId;
-                let folder_parent = [{userId, folder_parent_id}]
+                let userId: string = model.me.userId;
+                let folder_parent_id: string = $scope.selectedFoldersId;
+                let folder_parent = [{userId, folder_parent_id}];
                 mindmap = new MindmapFolder(name, folder_parent);
             }
 
@@ -452,7 +451,7 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
                 $scope.cancelMindmapEdit();
                 toasts.confirm(idiom.translate("mindmap.create.done"));
                 template.open('mindmap', 'mindmap-list');
-                await $scope.IsShareOrNot($scope.selectedFoldersId);
+                await $scope.IsShare($scope.selectedFoldersId);
             } catch (e) {
                 toasts.warning(idiom.translate('mindmap.create.fail'));
                 throw(e);

--- a/src/main/resources/public/ts/controllers/main.ts
+++ b/src/main/resources/public/ts/controllers/main.ts
@@ -1,4 +1,4 @@
-import {ng, angular, moment, _, template, Behaviours, toasts, workspace, idiom} from 'entcore';
+import {ng, angular, moment, _, template, Behaviours, toasts, workspace, idiom as lang} from 'entcore';
 import http from 'axios';
 import {FolderItem, Folders, Mindmap, MindmapFolder} from '../model';
 import {Folder} from '../model';
@@ -45,8 +45,8 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
         $scope.selectedFoldersId = FOLDER_ITEM.ID_NULL;
         $scope.selectedFoldersIdMove = null;
         (window as any).LAZY_MODE = false;
-        $scope.nameLabel = idiom.translate('mindmap.checkbox.my')
-        $scope.nameLabelShare = idiom.translate('mindmap.checkbox.share')
+        $scope.nameLabel = lang.translate('mindmap.checkbox.my')
+        $scope.nameLabelShare = lang.translate('mindmap.checkbox.share')
         $scope.isCheckedLabelMy = true;
         $scope.isCheckedLabelShare = true;
         $scope.sortMindmap = async (isChecked: boolean): Promise<void> => {
@@ -88,7 +88,7 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
          * Create Folder for the root and add in the scope
          */
         $scope.setFolderRoot = function (): void {
-            let folder: FolderItem = new FolderItem(FOLDER_ITEM.ID_ROOT, idiom.translate('mindmap.folder.title.root')).setType(FOLDER_ITEM_TYPE.FOLDER);
+            let folder: FolderItem = new FolderItem(FOLDER_ITEM.ID_ROOT, lang.translate('mindmap.folder.title.root')).setType(FOLDER_ITEM_TYPE.FOLDER);
             let folderTab: FolderItem[] = [folder];
             $scope.foldersRoot = new Folders(folderTab, []);
         }
@@ -97,7 +97,7 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
          * Create Folder for the root and add in the scope in the tree of moveFolder
          */
         $scope.setFolderRootForMove = function (): void {
-            let folder: FolderItem = new FolderItem(FOLDER_ITEM.ID_ROOT, idiom.translate('mindmap.folder.title.root')).setType(FOLDER_ITEM_TYPE.FOLDER);
+            let folder: FolderItem = new FolderItem(FOLDER_ITEM.ID_ROOT, lang.translate('mindmap.folder.title.root')).setType(FOLDER_ITEM_TYPE.FOLDER);
             let folderTab: FolderItem[] = [folder];
             $scope.foldersRootMove = new Folders(folderTab, []);
         }
@@ -270,19 +270,19 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
             }
         }
 
-        $scope.openFolderById = async function (id: string, share: boolean, isMine: boolean): Promise<void> {
+        $scope.openFolderById = async function (id: string, isShare: boolean, isMine: boolean): Promise<void> {
             template.open('mindmap', 'mindmap-list');
             $timeout(function () {
                 $('body').trigger('whereami.update');
             }, 100)
-            if (!share) {
-                share = false;
+            if (!isShare) {
+                isShare = false;
             }
             if (!isMine) {
                 isMine = false;
             }
 
-            $scope.setFolderItem = await folderService.getFolderChildren(id, share, isMine)
+            $scope.setFolderItem = await folderService.getFolderChildren(id, isShare, isMine)
             $scope.folders.setFolders($scope.setFolderItem);
             $scope.mindmapsItem.setMindmaps($scope.setFolderItem);
             if (id !== $scope.selectedFoldersId) {
@@ -291,12 +291,10 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
         };
 
         $scope.IsShare = async (id: string): Promise<void> => {
-            if (!$scope.isCheckedLabelMy) {
-                await $scope.openFolderById(id, true, false);
-            } else if (!$scope.isCheckedLabelShare) {
-                await $scope.openFolderById(id, false, true);
-            } else {
+            if (!$scope.isCheckedLabelMy && !$scope.isCheckedLabelShare) {
                 await $scope.openFolderById(id, true, true);
+            } else {
+                await $scope.openFolderById(id, $scope.isCheckedLabelShare, $scope.isCheckedLabelMy);
             }
         }
 
@@ -313,10 +311,10 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
         $scope.updateFolder = async (id: string, unFolder: Folder): Promise<void> => {
             try {
                 await folderService.updateFolder(id, unFolder);
-                toasts.confirm(idiom.translate('mindmap.folder.update.done'));
+                toasts.confirm(lang.translate('mindmap.folder.update.done'));
                 await $scope.reloadView();
             } catch (e) {
-                toasts.warning(idiom.translate('mindmap.folder.update.fail'));
+                toasts.warning(lang.translate('mindmap.folder.update.fail'));
                 throw(e);
             }
         };
@@ -331,11 +329,11 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
         $scope.updateMindmap = async (id: string, mindmap: Mindmap): Promise<void> => {
             try {
                 await mindmapService.updateMindmap(id, mindmap);
-                toasts.confirm(idiom.translate('mindmap.update.done'));
+                toasts.confirm(lang.translate('mindmap.update.done'));
                 template.open('mindmap', 'mindmap-list');
                 await $scope.IsShare($scope.selectedFoldersId);
             } catch (e) {
-                toasts.warning(idiom.translate("mindmap.update.fail"));
+                toasts.warning(lang.translate("mindmap.update.fail"));
                 throw(e);
             }
         };
@@ -343,11 +341,11 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
         $scope.changeMindmapFolder = async (id: string, mindmap: Mindmap): Promise<void> => {
             try {
                 await mindmapService.changeMindmapFolder(id, mindmap);
-                toasts.confirm(idiom.translate('mindmap.update.done'));
+                toasts.confirm(lang.translate('mindmap.update.done'));
                 template.open('mindmap', 'mindmap-list');
                 await $scope.IsShare($scope.selectedFoldersId);
             } catch (e) {
-                toasts.warning(idiom.translate("mindmap.update.fail"));
+                toasts.warning(lang.translate("mindmap.update.fail"));
                 throw (e)
             }
         }
@@ -362,10 +360,10 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
             try {
                 await folderService.createFolder(folder);
                 $scope.display.createFolder = false;
-                toasts.confirm(idiom.translate('mindmap.folder.create.done'));
+                toasts.confirm(lang.translate('mindmap.folder.create.done'));
                 await $scope.reloadView();
             } catch (e) {
-                toasts.warning(idiom.translate('mindmap.folder.create.fail'));
+                toasts.warning(lang.translate('mindmap.folder.create.fail'));
                 throw (e);
 
             }
@@ -374,11 +372,11 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
         $scope.deleteFolder = async (id: string): Promise<void> => {
             try {
                 await folderService.deleteFolder(id);
-                toasts.confirm(idiom.translate('mindmap.folder.delete.done'));
+                toasts.confirm(lang.translate('mindmap.folder.delete.done'));
                 $scope.reloadView();
 
             } catch (e) {
-                toasts.warning(idiom.translate('mindmap.folder.delete.fail'));
+                toasts.warning(lang.translate('mindmap.folder.delete.fail'));
                 throw(e);
             }
         };
@@ -386,11 +384,11 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
         $scope.deleteMindmap = async (id: string): Promise<void> => {
             try {
                 await mindmapService.deleteMindmap(id);
-                toasts.confirm(idiom.translate('mindmap.delete.done'));
+                toasts.confirm(lang.translate('mindmap.delete.done'));
                 template.open('mindmap', 'mindmap-list');
                 await $scope.IsShare($scope.selectedFoldersId);
             } catch (e) {
-                toasts.warning(idiom.translate('mindmap.delete.fail'));
+                toasts.warning(lang.translate('mindmap.delete.fail'));
                 throw(e);
             }
 
@@ -449,11 +447,11 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
             try {
                 await mindmapService.createMindmap(mindmap);
                 $scope.cancelMindmapEdit();
-                toasts.confirm(idiom.translate("mindmap.create.done"));
+                toasts.confirm(lang.translate("mindmap.create.done"));
                 template.open('mindmap', 'mindmap-list');
                 await $scope.IsShare($scope.selectedFoldersId);
             } catch (e) {
-                toasts.warning(idiom.translate('mindmap.create.fail'));
+                toasts.warning(lang.translate('mindmap.create.fail'));
                 throw(e);
             }
         };

--- a/src/main/resources/public/ts/controllers/main.ts
+++ b/src/main/resources/public/ts/controllers/main.ts
@@ -76,11 +76,10 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
         }
 
         $scope.setFolderChildrenMindmap = async (id: string, isShare: boolean, isMine: boolean): Promise<void> => {
-            let folder: FolderItem[] = await folderService.getFolderChildren(id, true, true);
-            let mindmap: FolderItem[] = await folderService.getFolderChildren(id, isShare, isMine);
-            $scope.folders = new Folders(folder, []);
-            $scope.mindmapsItem = new Folders([], mindmap);
-            $scope.foldersMove = new Folders(folder, []);
+            let folderItem: FolderItem[] = await Promise.all(await folderService.getFolderChildren(id, isShare, isMine));
+            $scope.folders = new Folders(folderItem, []);
+            $scope.mindmapsItem = new Folders([], folderItem);
+            $scope.foldersMove = new Folders(folderItem, []);
         };
 
 
@@ -275,12 +274,6 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
             $timeout(function () {
                 $('body').trigger('whereami.update');
             }, 100)
-            if (!isShare) {
-                isShare = false;
-            }
-            if (!isMine) {
-                isMine = false;
-            }
 
             $scope.setFolderItem = await folderService.getFolderChildren(id, isShare, isMine)
             $scope.folders.setFolders($scope.setFolderItem);
@@ -431,18 +424,16 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
 
         };
 
-        $scope.createMindmap = async function (name: string): Promise<void> {
-
+        $scope.createMindmap = async function (name: string, description: string): Promise<void> {
+            let userId: string = model.me.userId;
+            let folder_parent_id: string = $scope.selectedFoldersId;
             $scope.forceToClose = true;
             var mindmap: MindmapFolder;
             if ($scope.selectedFoldersId == FOLDER_ITEM.ID_NULL) {
-                mindmap = new MindmapFolder(name);
-            } else {
-                let userId: string = model.me.userId;
-                let folder_parent_id: string = $scope.selectedFoldersId;
-                let folder_parent = [{userId, folder_parent_id}];
-                mindmap = new MindmapFolder(name, folder_parent);
+                folder_parent_id = null;
             }
+            let folder_parent: {} = [{userId, folder_parent_id}];
+            mindmap = new MindmapFolder(name, folder_parent, description);
 
             try {
                 await mindmapService.createMindmap(mindmap);

--- a/src/main/resources/public/ts/core/const/folderItem.ts
+++ b/src/main/resources/public/ts/core/const/folderItem.ts
@@ -3,4 +3,8 @@ import {idiom} from "entcore";
 export const FOLDER_ITEM = {
     ID_NULL: "null",
     ID_ROOT: "null",
+    FALSE_VALUE: "false",
+    TRUE_VALUE: "true",
+    MY_MINDMAP : "Mes cartes mentales",
+    MINDMAP_SHARE : "Cartes mentales partagées avec moi"
 };

--- a/src/main/resources/public/ts/core/const/folderItem.ts
+++ b/src/main/resources/public/ts/core/const/folderItem.ts
@@ -1,10 +1,5 @@
-import {idiom} from "entcore";
 
 export const FOLDER_ITEM = {
     ID_NULL: "null",
     ID_ROOT: "null",
-    FALSE_VALUE: "false",
-    TRUE_VALUE: "true",
-    MY_MINDMAP : "Mes cartes mentales",
-    MINDMAP_SHARE : "Cartes mentales partagées avec moi"
 };

--- a/src/main/resources/public/ts/directives/directive-folder/directive-folder-list.html
+++ b/src/main/resources/public/ts/directives/directive-folder/directive-folder-list.html
@@ -27,23 +27,23 @@
                                     <button class="cell" ng-click="vm.openFolder(folder)">
                                         <i18n>mindmap.folder.manage.open</i18n>
                                     </button>
-                                    <button class="cell" ng-click="display.updateFolder = true">
+                                    <button class="cell" ng-click="vm.display.updateFolder = true">
 
                                         <i18n>mindmap.folder.manage.rename</i18n>
                                     </button>
                                     <button class="cell"
-                                            ng-click="display.moveFolder = true; vm.treeFolder(folder._id);">
+                                            ng-click="vm.display.moveFolder = true; vm.treeFolder(folder._id);">
 
                                         <i18n>mindmap.folder.manage.move</i18n>
                                     </button>
-                                    <button class="cell" ng-click="display.deleteFolder = true">
+                                    <button class="cell" ng-click="vm.display.deleteFolder = true">
 
                                         <i18n>mindmap.folder.manage.delete</i18n>
                                     </button>
                                 </div>
                             </div>
                         </section>
-                        <lightbox show="display.updateFolder" on-close="display.updateFolder = false;"
+                        <lightbox show="vm.display.updateFolder" on-close="vm.display.updateFolder = false;"
                                   class="ng-isolate-scope">
                             <div class="content">
                                 <div class="twelve cell">
@@ -58,7 +58,7 @@
                                                ng-model="folderTitle">
                                     </div>
                                     <div class="row ng-scope">
-                                        <button ng-click="vm.RenameFolder(folder._id,folderTitle); display.updateFolder = false;"
+                                        <button ng-click="vm.RenameFolder(folder._id,folderTitle); vm.display.updateFolder = false;"
                                                 ng-disabled="!folderTitle"
                                                 class="right-magnet" disabled="disabled">
                                             <i18n><span class="no-style ng-scope">mindmap.folder.manage.rename</span>
@@ -74,7 +74,7 @@
                             </div>
 
                         </lightbox>
-                        <lightbox show="display.moveFolder" class="ng-isolate-scope">
+                        <lightbox show="vm.display.moveFolder" class="ng-isolate-scope">
 
                             <div class="content">
                                 <div class="twelve cell">
@@ -90,7 +90,7 @@
                                             <i18n><span class="no-style ng-scope">mindmap.folder.manage.move</span>
                                             </i18n>
                                         </button>
-                                        <button class="cancel right-magnet" ng-click="display.moveFolder = false;">
+                                        <button class="cancel right-magnet" ng-click="vm.display.moveFolder = false;">
                                             <i18n><span class="no-style ng-scope">mindmap.folder.buttonCancel</span>
                                             </i18n>
                                         </button>
@@ -100,7 +100,7 @@
                             </div>
 
                         </lightbox>
-                        <lightbox show="display.deleteFolder" on-close="display.deleteFolder = false;"
+                        <lightbox show="vm.display.deleteFolder" on-close="vm.display.deleteFolder = false;"
                                   class="ng-isolate-scope">
 
                             <div class="content">
@@ -115,12 +115,12 @@
 
                                     </div>
                                     <div class="row ng-scope">
-                                        <button ng-click="vm.deleteFolder(folder._id); display.deleteFolder = false;"
+                                        <button ng-click="vm.deleteFolder(folder._id); vm.display.deleteFolder = false;"
                                                 class="right-magnet">
                                             <i18n><span class="no-style ng-scope">mindmap.folder.manage.delete</span>
                                             </i18n>
                                         </button>
-                                        <button class="cancel right-magnet" ng-click="display.deleteFolder = false;">
+                                        <button class="cancel right-magnet" ng-click="vm.display.deleteFolder = false;">
                                             <i18n><span class="no-style ng-scope">mindmap.folder.buttonCancel</span>
                                             </i18n>
                                         </button>
@@ -163,21 +163,42 @@
                                     <button class="cell" ng-click="vm.openMindmap(mindmap)">
                                         <i18n>mindmap.folder.manage.open</i18n>
                                     </button>
-                                    <button class="cell" ng-click="display.updateMindmap = true">
-                                        <i18n>mindmap.folder.manage.rename</i18n>
-                                    </button>
+                                    <resource-right name="contrib" resource="mindmap">
+                                        <button class="cell" ng-click="vm.display.updateMindmap = true">
+                                            <i18n>mindmap.folder.manage.rename</i18n>
+                                        </button>
+                                    </resource-right>
                                     <button class="cell"
-                                            ng-click="display.moveMindmap = true; vm.treeFolder(folder._id);">
+                                            ng-click="vm.display.moveMindmap = true; vm.treeFolder(folder._id);">
                                         <i18n>mindmap.folder.manage.move</i18n>
                                     </button>
-                                    <button class="cell" ng-click="display.deleteMindmap = true">
-                                        <i18n>mindmap.folder.manage.delete</i18n>
+                                    <resource-right name="manage" resource="mindmap">
+                                        <button class="cell" ng-click="vm.display.deleteMindmap = true">
+                                            <i18n>mindmap.folder.manage.delete</i18n>
+                                        </button>
+                                    </resource-right>
+                                    <resource-right name="contrib" resource="mindmap">
+                                        <button
+                                                ng-click="vm.editMindmap(mindmap, $event)">
+                                            <i18n>properties</i18n>
+                                        </button>
+                                    </resource-right>
+                                    <button
+                                            library-resource="mindmap">
+                                        <i18n>bpr.publish</i18n>
+                                    </button>
+                                    <button
+                                            ng-click="vm.printPngMindmap(mindmap, $event)">
+                                        <i18n>print</i18n>
+                                    </button>
+                                    <button ng-click="vm.shareMindmap(mindmap, $event)">
+                                        <i18n>share</i18n>
                                     </button>
                                 </div>
                             </div>
 
                         </section>
-                        <lightbox show="display.updateMindmap" on-close="display.updateMindmap = false;"
+                        <lightbox show="vm.display.updateMindmap" on-close="vm.display.updateMindmap = false;"
                                   class="ng-isolate-scope">
 
 
@@ -194,13 +215,14 @@
                                                ng-model="mindmapTitle">
                                     </div>
                                     <div class="row ng-scope">
-                                        <button ng-click="vm.RenameMindmap(mindmap._id,mindmapTitle); display.updateMindmap = false;"
+                                        <button ng-click="vm.RenameMindmap(mindmap._id,mindmapTitle); vm.display.updateMindmap = false;"
                                                 ng-disabled="!mindmapTitle"
                                                 class="right-magnet" disabled="disabled">
                                             <i18n><span class="no-style ng-scope">mindmap.folder.manage.rename</span>
                                             </i18n>
                                         </button>
-                                        <button class="cancel right-magnet" ng-click="display.updateMindmap = false;">
+                                        <button class="cancel right-magnet"
+                                                ng-click="vm.display.updateMindmap = false;">
                                             <i18n><span class="no-style ng-scope">mindmap.folder.buttonCancel</span>
                                             </i18n>
                                         </button>
@@ -210,7 +232,7 @@
                             </div>
 
                         </lightbox>
-                        <lightbox show="display.moveMindmap" class="ng-isolate-scope">
+                        <lightbox show="vm.display.moveMindmap" class="ng-isolate-scope">
 
                             <div class="content">
                                 <div class="twelve cell">
@@ -226,7 +248,7 @@
                                             <i18n><span class="no-style ng-scope">mindmap.folder.manage.move</span>
                                             </i18n>
                                         </button>
-                                        <button class="cancel right-magnet" ng-click="display.moveMindmap = false;">
+                                        <button class="cancel right-magnet" ng-click="vm.display.moveMindmap = false;">
                                             <i18n><span class="no-style ng-scope">mindmap.folder.buttonCancel</span>
                                             </i18n>
                                         </button>
@@ -236,7 +258,7 @@
                             </div>
 
                         </lightbox>
-                        <lightbox show="display.deleteMindmap" on-close="display.deleteMindmap = false;"
+                        <lightbox show="vm.display.deleteMindmap" on-close="vm.display.deleteMindmap = false;"
                                   class="ng-isolate-scope">
 
 
@@ -251,12 +273,13 @@
 
                                     </div>
                                     <div class="row ng-scope">
-                                        <button ng-click="vm.deleteMindmap(mindmap._id); display.deleteMindmap = false;"
+                                        <button ng-click="vm.deleteMindmap(mindmap._id); vm.display.deleteMindmap = false;"
                                                 class="right-magnet">
                                             <i18n><span class="no-style ng-scope">mindmap.folder.manage.delete</span>
                                             </i18n>
                                         </button>
-                                        <button class="cancel right-magnet" ng-click="display.deleteMindmap = false;">
+                                        <button class="cancel right-magnet"
+                                                ng-click="vm.display.deleteMindmap = false;">
                                             <i18n><span class="no-style ng-scope">mindmap.folder.buttonCancel</span>
                                             </i18n>
                                         </button>
@@ -264,13 +287,14 @@
                                 </div>
 
                             </div>
-
                         </lightbox>
+
                     </div>
 
                 </div>
 
             </div>
+
 
         </article>
         <div class="emptyscreen ng-scope" ng-if="vm.folders.length == 0 && vm.mindmapsItem.length == 0">
@@ -288,6 +312,7 @@
             </a>
         </div>
     </div>
+
 
 </section>
 

--- a/src/main/resources/public/ts/directives/directive-folder/directive-folder-list.html
+++ b/src/main/resources/public/ts/directives/directive-folder/directive-folder-list.html
@@ -4,7 +4,7 @@
             <div class="fallen dominos" class="element mini-block-container">
                 <div ng-repeat="folder in vm.folders ">
                     <explorer ng-model="folder.selected" on-open="vm.openFolder(folder)"
-                              class="ng-pristine ng-untouched ng-valid ng-isolate-scope ng-not-empty">
+                              class="ng-pristine ng-untouched ng-valid ng-not-empty">
                         <a class="container" draggable="false">
                             <i class="folder-large" dragstart="vm.drag(folder, $originalEvent)"
                                dragdrop="vm.dropToFolder(folder, $originalEvent)"
@@ -43,8 +43,7 @@
                                 </div>
                             </div>
                         </section>
-                        <lightbox show="vm.display.updateFolder" on-close="vm.display.updateFolder = false;"
-                                  class="ng-isolate-scope">
+                        <lightbox show="vm.display.updateFolder" on-close="vm.display.updateFolder = false;">
                             <div class="content">
                                 <div class="twelve cell">
                                     <h2 class="ng-scope">
@@ -74,7 +73,7 @@
                             </div>
 
                         </lightbox>
-                        <lightbox show="vm.display.moveFolder" class="ng-isolate-scope">
+                        <lightbox show="vm.display.moveFolder">
 
                             <div class="content">
                                 <div class="twelve cell">
@@ -100,9 +99,7 @@
                             </div>
 
                         </lightbox>
-                        <lightbox show="vm.display.deleteFolder" on-close="vm.display.deleteFolder = false;"
-                                  class="ng-isolate-scope">
-
+                        <lightbox show="vm.display.deleteFolder" on-close="vm.display.deleteFolder = false;">
                             <div class="content">
                                 <div class="twelve cell">
                                     <h2 class="ng-scope">
@@ -198,8 +195,7 @@
                             </div>
 
                         </section>
-                        <lightbox show="vm.display.updateMindmap" on-close="vm.display.updateMindmap = false;"
-                                  class="ng-isolate-scope">
+                        <lightbox show="vm.display.updateMindmap" on-close="vm.display.updateMindmap = false;">
 
 
                             <div class="content">
@@ -232,7 +228,7 @@
                             </div>
 
                         </lightbox>
-                        <lightbox show="vm.display.moveMindmap" class="ng-isolate-scope">
+                        <lightbox show="vm.display.moveMindmap">
 
                             <div class="content">
                                 <div class="twelve cell">

--- a/src/main/resources/public/ts/directives/directive-folder/directive-folder-list.ts
+++ b/src/main/resources/public/ts/directives/directive-folder/directive-folder-list.ts
@@ -216,9 +216,9 @@ export const directiveFolderList = ng.directive('directiveFolderList', () => {
                 let targetId: string = targetItem._id;
 
                 if (originalItem.type === FOLDER_ITEM_TYPE.MINDMAP) {
-                    var userId: string = "userId";
-                    var folder_parent_id: string = targetId
-                    var folder_parent = {userId, folder_parent_id}
+                    let userId: string = "userId";
+                    let folder_parent_id: string = targetId
+                    let folder_parent = {userId, folder_parent_id}
                     let mindmapBody: MindmapFolder = new MindmapFolder(originalItem.name.toString(), folder_parent);
                     $scope.$eval(vm.onChangeMindmapFolder)(originId, mindmapBody);
 

--- a/src/main/resources/public/ts/directives/directive-folder/directive-folder-list.ts
+++ b/src/main/resources/public/ts/directives/directive-folder/directive-folder-list.ts
@@ -1,6 +1,6 @@
 import {$, ng,} from "entcore";
 import {ROOTS} from "../../core/const/roots";
-import {Folder, FolderItem, Mindmap, MindmapFolder} from "../../model";
+import {Folder, FolderItem, Mindmap, MindmapFolder, Mindmaps} from "../../model";
 import {FOLDER_ITEM_TYPE} from "../../core/const/type";
 
 interface IViewModel {
@@ -56,12 +56,30 @@ interface IViewModel {
 
     moveMindmap(id: string, name: string): void;
 
+    editMindmap(mindmap: Mindmap, $event): void;
+
+    onEditMindmap(): void;
+
+    shareMindmap(mindmap: Mindmap, $event): void;
+
+    onShareMindmap(): void;
+
+    printPngMindmap(mindmap: Mindmap, $event): void;
+
+    onPrintPngMindmap(): void;
+
+    onChangeMindmapFolder(): void;
+
+
     id: string;
     name: string;
     folderParentId: string;
     ownerId: string;
     folders: FolderItem[];
-    mindmapsItem: FolderItem[];
+    mindmapsItem: Mindmap[];
+    display: {
+        showPanel: boolean;
+    }
 
 }
 
@@ -84,6 +102,10 @@ export const directiveFolderList = ng.directive('directiveFolderList', () => {
             treeMoveFolder: '&',
             onMoveMindmap: '&',
             selectedFoldersId: '=',
+            onEditMindmap: '&',
+            onShareMindmap: '&',
+            onPrintPngMindmap: '&',
+            onChangeMindmapFolder: '&',
         },
 
         restrict: 'E',
@@ -105,6 +127,18 @@ export const directiveFolderList = ng.directive('directiveFolderList', () => {
 
         link: function ($scope) {
             const vm: IViewModel = $scope.vm;
+
+            vm.printPngMindmap = (mindmap: Mindmap, $event): void => {
+                $scope.$eval(vm.onPrintPngMindmap)(mindmap, $event)
+            }
+
+            vm.shareMindmap = (mindmap: Mindmap, $event): void => {
+                $scope.$eval(vm.onShareMindmap)(mindmap, $event)
+            }
+
+            vm.editMindmap = (mindmap: Mindmap, $event): void => {
+                $scope.$eval(vm.onEditMindmap)(mindmap, $event);
+            }
 
             vm.treeFolder = (id: string) => {
                 $scope.$eval(vm.treeMoveFolder)(id);
@@ -149,7 +183,7 @@ export const directiveFolderList = ng.directive('directiveFolderList', () => {
             }
 
 
-            vm.drag = function (item: FolderItem, $originalEvent): void {
+            vm.drag = function (item: FolderItem | Mindmap, $originalEvent): void {
                 try {
                     $originalEvent.dataTransfer.setData('application/json', JSON.stringify(item));
                 } catch (e) {
@@ -181,9 +215,12 @@ export const directiveFolderList = ng.directive('directiveFolderList', () => {
                 let originId: string = originalItem._id;
                 let targetId: string = targetItem._id;
 
-                if (originalItem.type == FOLDER_ITEM_TYPE.MINDMAP) {
-                    let mindmapBody: MindmapFolder = new MindmapFolder(originalItem.name.toString(), targetId);
-                    $scope.$eval(vm.onUpdateMindmap)(originId, mindmapBody);
+                if (originalItem.type === FOLDER_ITEM_TYPE.MINDMAP) {
+                    var userId: string = "userId";
+                    var folder_parent_id: string = targetId
+                    var folder_parent = {userId, folder_parent_id}
+                    let mindmapBody: MindmapFolder = new MindmapFolder(originalItem.name.toString(), folder_parent);
+                    $scope.$eval(vm.onChangeMindmapFolder)(originId, mindmapBody);
 
                 } else {
                     let folderBody: Folder = new Folder(originalItem.name.toString(), targetId);

--- a/src/main/resources/public/ts/directives/directive-label-share/directive-label-share.html
+++ b/src/main/resources/public/ts/directives/directive-label-share/directive-label-share.html
@@ -1,0 +1,5 @@
+<label class="chip checkbox ng-scope" ng-class="{selected: vm.isChecked == true }">
+    <i18n class="ng-binding"><span class="no-style ng-binding ng-scope">{{vm.name}}</span></i18n>
+    <input type="checkbox" ng-click=" vm.sort()">
+</label>
+

--- a/src/main/resources/public/ts/directives/directive-label-share/directive-label-share.ts
+++ b/src/main/resources/public/ts/directives/directive-label-share/directive-label-share.ts
@@ -1,0 +1,52 @@
+import {ng} from "entcore";
+import {ROOTS} from "../../core/const/roots";
+
+
+interface IViewModel {
+    $onInit();
+
+    $onDestroy();
+
+    onSort(): void;
+
+
+    sort(): void;
+
+    name: string;
+    isChecked: boolean;
+}
+
+export const directiveLabelShare = ng.directive('directiveLabelShare', () => {
+    return {
+        templateUrl: `${ROOTS.directive}directive-label-share/directive-label-share.html`,
+        scope: {
+            onSort: '&',
+            name: '=',
+            isChecked: '='
+        },
+        restrict: 'E',
+        controllerAs: 'vm',
+        bindToController: true,
+        replace: false,
+        controller: function () {
+            const vm: IViewModel = <IViewModel>this;
+            vm.$onInit = async () => {
+                vm.isChecked = false;
+            };
+
+            vm.$onDestroy = async () => {
+                vm.isChecked = false;
+            };
+        },
+        link: function ($scope) {
+            const vm: IViewModel = $scope.vm;
+
+            vm.sort = (): void => {
+                vm.isChecked = !vm.isChecked;
+                $scope.$eval(vm.onSort)(vm.isChecked);
+            }
+
+
+        }
+    }
+})

--- a/src/main/resources/public/ts/directives/directive-label-share/directive-label-share.ts
+++ b/src/main/resources/public/ts/directives/directive-label-share/directive-label-share.ts
@@ -31,11 +31,11 @@ export const directiveLabelShare = ng.directive('directiveLabelShare', () => {
         controller: function () {
             const vm: IViewModel = <IViewModel>this;
             vm.$onInit = async () => {
-                vm.isChecked = false;
+                vm.isChecked = true;
             };
 
             vm.$onDestroy = async () => {
-                vm.isChecked = false;
+                vm.isChecked = true;
             };
         },
         link: function ($scope) {

--- a/src/main/resources/public/ts/directives/index.ts
+++ b/src/main/resources/public/ts/directives/index.ts
@@ -1,2 +1,3 @@
 export * from './mindmapEditor';
 export * from './directive-folder/directive-folder-list';
+export * from './directive-label-share/directive-label-share';

--- a/src/main/resources/public/ts/model/Folder.ts
+++ b/src/main/resources/public/ts/model/Folder.ts
@@ -61,7 +61,7 @@ export class Folders {
 
     constructor(folderTab: FolderItem[], mindmapsTab: FolderItem[]) {
         this.all = folderTab.filter((folder: FolderItem) => folder.type == FOLDER_ITEM_TYPE.FOLDER);
-        this.mindmapsAll = mindmapsTab.filter((folder: Mindmap) => folder.type == FOLDER_ITEM_TYPE.MINDMAP);
+        this.mindmapsAll = mindmapsTab.filter((mindmap: Mindmap) => mindmap.type == FOLDER_ITEM_TYPE.MINDMAP);
         this.trees = [];
         this.mindmapsRight = this.mindmapsAll.map((mindmap: Mindmap) => Behaviours.applicationsBehaviours.mindmap.resource(new Mindmap(mindmap)));
     }

--- a/src/main/resources/public/ts/model/Folder.ts
+++ b/src/main/resources/public/ts/model/Folder.ts
@@ -1,8 +1,10 @@
 import {Mix} from "entcore-toolkit";
-import {workspace} from "entcore";
+import {Behaviours, workspace} from "entcore";
 import models = workspace.v2.models;
 import {FolderItem} from "./FolderItem";
 import {FOLDER_ITEM_TYPE} from "../core/const/type";
+import {Mindmap} from "./Mindmap";
+import {Mindmaps} from "./Mindmaps";
 
 export class FolderView {
     _id?: string;
@@ -25,6 +27,10 @@ export class Folder extends FolderView {
     name: string;
     folder_parent_id: string;
     type?: string;
+    owner: {
+        userId: string;
+        displayName: string;
+    }
 
 
     constructor(name?, folder_parent_id?) {
@@ -37,6 +43,7 @@ export class Folder extends FolderView {
 export class Folders {
     all: FolderItem[];
     mindmapsAll: FolderItem[];
+    mindmapsRight : Mindmaps[];
     pageCount: number;
     id: string;
     name: string;
@@ -47,11 +54,19 @@ export class Folders {
     sharedFormsFolder?: Folder;
     archivedFormsFolder?: Folder;
     children: FolderItem[];
+    owner: {
+        userId: string;
+        displayName: string;
+    }
 
     constructor(folderTab: FolderItem[], mindmapsTab: FolderItem[]) {
         this.all = folderTab.filter((folder: FolderItem) => folder.type == FOLDER_ITEM_TYPE.FOLDER);
-        this.mindmapsAll = mindmapsTab.filter((folder: FolderItem) => folder.type == FOLDER_ITEM_TYPE.MINDMAP);
+        this.mindmapsAll = mindmapsTab.filter((folder: Mindmap) => folder.type == FOLDER_ITEM_TYPE.MINDMAP);
         this.trees = [];
+        this.mindmapsRight = this.mindmapsAll.map((mindmap :Mindmap)=> Behaviours.applicationsBehaviours.mindmap.resource(new Mindmap(mindmap)));
+        for(var mindmapRight of this.mindmapsAll) {
+
+        }
     }
 
 
@@ -69,6 +84,7 @@ export class Folders {
 
     setMindmaps = (mindmaps: FolderItem[]): void => {
         this.mindmapsAll = mindmaps.filter((folder: FolderItem) => folder.type == FOLDER_ITEM_TYPE.MINDMAP);
+        this.mindmapsRight = this.mindmapsAll.map((mindmap :Mindmap)=> Behaviours.applicationsBehaviours.mindmap.resource(new Mindmap(mindmap)));
     }
 
     findTree = (currentFolders: models.Element[], id: string): models.Element => {

--- a/src/main/resources/public/ts/model/Folder.ts
+++ b/src/main/resources/public/ts/model/Folder.ts
@@ -43,7 +43,7 @@ export class Folder extends FolderView {
 export class Folders {
     all: FolderItem[];
     mindmapsAll: FolderItem[];
-    mindmapsRight : Mindmaps[];
+    mindmapsRight: Mindmaps[];
     pageCount: number;
     id: string;
     name: string;
@@ -63,10 +63,7 @@ export class Folders {
         this.all = folderTab.filter((folder: FolderItem) => folder.type == FOLDER_ITEM_TYPE.FOLDER);
         this.mindmapsAll = mindmapsTab.filter((folder: Mindmap) => folder.type == FOLDER_ITEM_TYPE.MINDMAP);
         this.trees = [];
-        this.mindmapsRight = this.mindmapsAll.map((mindmap :Mindmap)=> Behaviours.applicationsBehaviours.mindmap.resource(new Mindmap(mindmap)));
-        for(var mindmapRight of this.mindmapsAll) {
-
-        }
+        this.mindmapsRight = this.mindmapsAll.map((mindmap: Mindmap) => Behaviours.applicationsBehaviours.mindmap.resource(new Mindmap(mindmap)));
     }
 
 
@@ -84,7 +81,7 @@ export class Folders {
 
     setMindmaps = (mindmaps: FolderItem[]): void => {
         this.mindmapsAll = mindmaps.filter((folder: FolderItem) => folder.type == FOLDER_ITEM_TYPE.MINDMAP);
-        this.mindmapsRight = this.mindmapsAll.map((mindmap :Mindmap)=> Behaviours.applicationsBehaviours.mindmap.resource(new Mindmap(mindmap)));
+        this.mindmapsRight = this.mindmapsAll.map((mindmap: Mindmap) => Behaviours.applicationsBehaviours.mindmap.resource(new Mindmap(mindmap)));
     }
 
     findTree = (currentFolders: models.Element[], id: string): models.Element => {

--- a/src/main/resources/public/ts/model/FolderItem.ts
+++ b/src/main/resources/public/ts/model/FolderItem.ts
@@ -1,5 +1,6 @@
 import {Mindmap} from "./Mindmap";
 import http from "axios";
+import {Rights, Shareable} from "entcore";
 
 export class FolderItemView {
     _id?: string;
@@ -11,13 +12,15 @@ export class FolderItemView {
         displayName?: string;
     }
     type?: string;
+    rights? :any;
+    shared?: any
 }
 
 export interface IFolderItem extends FolderItemView {
     name: string;
 }
 
-export class FolderItem extends FolderItemView {
+export class FolderItem extends FolderItemView{
     id: string;
     name: string;
     folder_parent_id: string;
@@ -26,18 +29,39 @@ export class FolderItem extends FolderItemView {
     description: string;
     map: string;
     thumbnail: string;
+    rights :any;
+    shared: any;
+    owner: {
+        userId: string;
+        displayName: string;
+    }
 
     constructor(id?: string, name?: string, folder_parent_id?: string) {
         super();
         this.id = id;
         this.name = name;
         this.folder_parent_id = folder_parent_id;
+
     }
+
+
+    toJSON() {
+        return {
+            _id : this._id,
+            name: this.name,
+            folder_parent_id: this.folder_parent_id,
+            type: this.type
+        };
+    };
+
+
 
     setType(type: string): FolderItem {
         this.type = type;
         return this;
     }
+
+
 
     async save(): Promise<void> {
         await this.update();

--- a/src/main/resources/public/ts/model/FolderItem.ts
+++ b/src/main/resources/public/ts/model/FolderItem.ts
@@ -12,7 +12,7 @@ export class FolderItemView {
         displayName?: string;
     }
     type?: string;
-    rights? :any;
+    rights?: any;
     shared?: any
 }
 
@@ -20,7 +20,7 @@ export interface IFolderItem extends FolderItemView {
     name: string;
 }
 
-export class FolderItem extends FolderItemView{
+export class FolderItem extends FolderItemView {
     id: string;
     name: string;
     folder_parent_id: string;
@@ -29,7 +29,7 @@ export class FolderItem extends FolderItemView{
     description: string;
     map: string;
     thumbnail: string;
-    rights :any;
+    rights: any;
     shared: any;
     owner: {
         userId: string;
@@ -47,7 +47,7 @@ export class FolderItem extends FolderItemView{
 
     toJSON() {
         return {
-            _id : this._id,
+            _id: this._id,
             name: this.name,
             folder_parent_id: this.folder_parent_id,
             type: this.type
@@ -55,12 +55,10 @@ export class FolderItem extends FolderItemView{
     };
 
 
-
     setType(type: string): FolderItem {
         this.type = type;
         return this;
     }
-
 
 
     async save(): Promise<void> {

--- a/src/main/resources/public/ts/model/Mindmap.ts
+++ b/src/main/resources/public/ts/model/Mindmap.ts
@@ -1,14 +1,16 @@
 import {model, Rights, Shareable} from 'entcore';
 import http from 'axios';
 import {Mix, Selectable} from "entcore-toolkit";
+import {FolderItem} from "./FolderItem";
 
 /**
  * Model to create a mindmap.
  */
-export class Mindmap implements Selectable, Shareable {
+export class Mindmap extends FolderItem implements Selectable, Shareable{
     _id: any;
+    id:string
     name: any;
-    folder_parent_id: string;
+    folder_parent:{};
     description: any;
     thumbnail: any;
     map: any;
@@ -16,8 +18,11 @@ export class Mindmap implements Selectable, Shareable {
     selected: boolean;
     shared: any
     owner: any
+    type: string;
+    mindmap: Mindmap;
 
     constructor(mindmap?) {
+        super();
         this.rights = new Rights(this);
         this.rights.fromBehaviours();
 
@@ -25,6 +30,36 @@ export class Mindmap implements Selectable, Shareable {
             Mix.extend(this, mindmap);
         }
     };
+
+    setType(type: string): FolderItem {
+        this.type = type;
+        return this;
+    }
+
+
+
+    async save(): Promise<void> {
+        await this.update();
+    };
+
+    toJSONSave(): Object {
+        return {
+            name: this.name,
+            description: this.description,
+            thumbnail: this.thumbnail,
+            map: this.map,
+            folder_parent_id : this.folder_parent_id,
+            type : this.type,
+        };
+    };
+
+    setFromElement(elem: any): FolderItem {
+        this.id = elem._id;
+        this.name = elem.name;
+        this.folder_parent_id = elem.folder_parent_id;
+        this.type = elem.type;
+        return this;
+    }
 
 
     get myRights() {
@@ -60,14 +95,23 @@ export class Mindmap implements Selectable, Shareable {
      * Allows to convert the current mindmap into a JSON format.
      * @return the current mindmap in JSON format.
      */
-    toJSON() {
+     toJSON() {
         return {
+            _id : this._id,
             name: this.name,
-            description: this.description,
-            thumbnail: this.thumbnail,
-            map: this.map
+            folder_parent_id: this.folder_parent_id,
+            type: this.type
         };
     };
+
+    public toJson() {
+        return {
+            _id : this._id,
+            name: this.name,
+            folder_parent_id: this.folder_parent_id,
+            type: this.type
+        };
+    }
 };
 
 export class MindmapView {
@@ -86,13 +130,16 @@ export class MindmapView {
 export class MindmapFolder extends MindmapView {
     id: string;
     name: string;
-    folder_parent_id: string;
+    folder_parent: {};
+    description : string;
+    thumbnail: any;
 
 
-    constructor(name?, folder_parent_id?) {
+    constructor(name?, folder_parent?, description?) {
         super();
         this.name = name;
-        this.folder_parent_id = folder_parent_id;
+        this.folder_parent = folder_parent;
+        this.description = description;
     }
 }
 

--- a/src/main/resources/public/ts/model/Mindmap.ts
+++ b/src/main/resources/public/ts/model/Mindmap.ts
@@ -6,11 +6,11 @@ import {FolderItem} from "./FolderItem";
 /**
  * Model to create a mindmap.
  */
-export class Mindmap extends FolderItem implements Selectable, Shareable{
+export class Mindmap extends FolderItem implements Selectable, Shareable {
     _id: any;
-    id:string
+    id: string
     name: any;
-    folder_parent:{};
+    folder_parent: {};
     description: any;
     thumbnail: any;
     map: any;
@@ -37,19 +37,18 @@ export class Mindmap extends FolderItem implements Selectable, Shareable{
     }
 
 
-
     async save(): Promise<void> {
         await this.update();
     };
 
-    toJSONSave(): Object {
+    toJSONSave(): {} {
         return {
             name: this.name,
             description: this.description,
             thumbnail: this.thumbnail,
             map: this.map,
-            folder_parent_id : this.folder_parent_id,
-            type : this.type,
+            folder_parent_id: this.folder_parent_id,
+            type: this.type,
         };
     };
 
@@ -95,9 +94,9 @@ export class Mindmap extends FolderItem implements Selectable, Shareable{
      * Allows to convert the current mindmap into a JSON format.
      * @return the current mindmap in JSON format.
      */
-     toJSON() {
+    toJSON() {
         return {
-            _id : this._id,
+            _id: this._id,
             name: this.name,
             folder_parent_id: this.folder_parent_id,
             type: this.type
@@ -106,7 +105,7 @@ export class Mindmap extends FolderItem implements Selectable, Shareable{
 
     public toJson() {
         return {
-            _id : this._id,
+            _id: this._id,
             name: this.name,
             folder_parent_id: this.folder_parent_id,
             type: this.type
@@ -131,7 +130,7 @@ export class MindmapFolder extends MindmapView {
     id: string;
     name: string;
     folder_parent: {};
-    description : string;
+    description: string;
     thumbnail: any;
 
 

--- a/src/main/resources/public/ts/services/folder.service.ts
+++ b/src/main/resources/public/ts/services/folder.service.ts
@@ -6,7 +6,7 @@ import {FolderItem} from "../model/FolderItem";
 
 
 export interface FolderService {
-    getFolderChildren(folderId: string, isShare: string, isMine: string): Promise<FolderItem[]>;
+    getFolderChildren(folderId: string, isShare: Boolean, isMine: Boolean): Promise<FolderItem[]>;
 
 
     createFolder(folderBody: IFolder): Promise<AxiosResponse>;
@@ -18,10 +18,9 @@ export interface FolderService {
 }
 
 export const folderService: FolderService = {
-    getFolderChildren: async (folderId: string, isShare: string, isMine: string): Promise<FolderItem[]> => {
+    getFolderChildren: async (folderId: string, isShare: boolean, isMine: boolean): Promise<FolderItem[]> => {
         try {
-            let {data} = await http.get(`/mindmap/folders/${folderId}/children/${isShare}/${isMine}`);
-
+            let {data} = await http.get(`/mindmap/folders/${folderId}/children/share/${isShare}/mine/${isMine}`);
             return Mix.castArrayAs(FolderItem, data);
         } catch (err) {
             throw err;

--- a/src/main/resources/public/ts/services/folder.service.ts
+++ b/src/main/resources/public/ts/services/folder.service.ts
@@ -6,7 +6,7 @@ import {FolderItem} from "../model/FolderItem";
 
 
 export interface FolderService {
-    getFolderChildren(folderId: string): Promise<FolderItem[]>;
+    getFolderChildren(folderId: string, isShare: string, isMine: string): Promise<FolderItem[]>;
 
 
     createFolder(folderBody: IFolder): Promise<AxiosResponse>;
@@ -18,9 +18,9 @@ export interface FolderService {
 }
 
 export const folderService: FolderService = {
-    getFolderChildren: async (folderId: string): Promise<FolderItem[]> => {
+    getFolderChildren: async (folderId: string, isShare: string, isMine: string): Promise<FolderItem[]> => {
         try {
-            let {data} = await http.get(`/mindmap/folders/${folderId}/children`);
+            let {data} = await http.get(`/mindmap/folders/${folderId}/children/${isShare}/${isMine}`);
 
             return Mix.castArrayAs(FolderItem, data);
         } catch (err) {
@@ -32,11 +32,11 @@ export const folderService: FolderService = {
         return await http.post(`/mindmap/folder`, folderBody);
     },
 
-    updateFolder: async(id: string, folderBody: IFolder): Promise<AxiosResponse> => {
-        return await http.put(`/mindmap/folders/${id}`,folderBody);
+    updateFolder: async (id: string, folderBody: IFolder): Promise<AxiosResponse> => {
+        return await http.put(`/mindmap/folders/${id}`, folderBody);
     },
 
-    deleteFolder: async(id: string): Promise<AxiosResponse> =>{
+    deleteFolder: async (id: string): Promise<AxiosResponse> => {
         return await http.delete(`/mindmap/folders/${id}`);
     },
 };

--- a/src/main/resources/public/ts/services/mindmap.service.ts
+++ b/src/main/resources/public/ts/services/mindmap.service.ts
@@ -12,6 +12,9 @@ export interface MindmapService {
     deleteMindmap(id: string): Promise<AxiosResponse>;
 
     createMindmap(mindmaBody: MindmapFolder): Promise<AxiosResponse>;
+
+    changeMindmapFolder(id: string, mindmapBody: Mindmap): Promise<AxiosResponse>;
+
 }
 
 export const mindmapService: MindmapService = {
@@ -26,6 +29,10 @@ export const mindmapService: MindmapService = {
 
     updateMindmap: async (id: string, mindmapBody: Mindmap): Promise<AxiosResponse> => {
         return await http.put(`/mindmap/${id}`, mindmapBody);
+    },
+
+    changeMindmapFolder: async (id: string, mindmapBody: Mindmap): Promise<AxiosResponse> => {
+        return await http.put(`/mindmap/move/${id}`, mindmapBody);
     },
 
     deleteMindmap: async (id: string): Promise<AxiosResponse> => {


### PR DESCRIPTION
Evolution du module Mindmap(Carte Mentale) : ajouter une gestion de dossier pour pouvoir trier les cartes mentales.
Dans cette Evolution a été rajouté :
- remettre les boutons des cartes mentales dans la toolbar(partage, propriétés ) 
- pouvoir ranger les cartes mentales partagées dans des dossiers 
- gérer l'affichage des boutons en fonction des droits accordés sur les cartes mentales partagés
- ajout de deux boutons pour afficher que les cartes mentales partagées ou ses propres cartes mentales