### PR TITLE
fix(mindmap):#MO-137 adjust 1D theme for folder evolution

### DIFF
--- a/src/main/resources/public/template/mindmap-list.html
+++ b/src/main/resources/public/template/mindmap-list.html
@@ -3,13 +3,13 @@
 <div class="twelve cell" workflow="mindmap.list">
     <div class="row top-spacing-twice">
         <!-- Search bar -->
-        <div class="two cell">
+        <div class="three cell">
 
             <nav class="vertical mobile-navigation side-nav" side-nav style="height: auto;">
                 <folder-tree tree-props="folderTreeRoot"></folder-tree>
-                <a class="classic-link" ng-click="display.createFolder = true">
-                    <i18n><span class="no-style ng-scope">mindmap.folder.create</span></i18n>
-                </a>
+                <button class="left-one ten top-spacing-three" ng-click="display.createFolder = true;">
+                    <i18n>mindmap.folder.create</i18n>
+                </button>
             </nav>
 
         </div>

--- a/src/main/resources/public/ts/directives/directive-folder/directive-folder-list.html
+++ b/src/main/resources/public/ts/directives/directive-folder/directive-folder-list.html
@@ -1,4 +1,4 @@
-<section class="ten cell twelve-mobile">
+<section class="nine cell twelve-mobile">
 
 
     </div>

--- a/src/main/resources/public/ts/directives/directive-label-share/directive-label-share.html
+++ b/src/main/resources/public/ts/directives/directive-label-share/directive-label-share.html
@@ -1,4 +1,4 @@
-<label class="chip checkbox ng-scope" ng-class="{selected: vm.isChecked == true }">
+<label class="chip" ng-class="{selected: vm.isChecked == true }">
     <i18n class="ng-binding"><span class="no-style ng-binding ng-scope">{{vm.name}}</span></i18n>
     <input type="checkbox" ng-click=" vm.sort()">
 </label>


### PR DESCRIPTION
## Describe your changes
Modification du html pour réajuster le thème 1D sur carte mentale qui été dégradé par l'évolution sur la création de dossiers.
Carte mentale theme 1D avant l'evolution pour les dossiers : 
<img width="960" alt="Mindmap-1 12 6" src="https://user-images.githubusercontent.com/81428770/168835273-fbecad97-8f25-4c6f-876b-ac49bd31cbe5.PNG">

Carte mentale theme 1D apres l'evolution pour les dossiers : 
![Mindmap régression](https://user-images.githubusercontent.com/81428770/168835403-4f7b68bd-2414-407b-ac5c-3f3cd9c26583.png)

Carte mentale theme 1D apres l'evolution pour les dossiers et le correctif apporté : 
<img width="724" alt="Mindmap evol theme 1D" src="https://user-images.githubusercontent.com/81428770/168835718-fc7073ed-bda0-4d1c-ae97-533b25494834.png">

## Checklist tests

## Issue ticket number and link
MO-137 : https://entsupport.gdapublic.fr/projects/MO/issues/MO-137

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

