### PR TITLE
fix(share): #CO-1682 fix error when clicking on mindmap share notific…

### DIFF
--- a/src/main/resources/public/ts/controllers/main.ts
+++ b/src/main/resources/public/ts/controllers/main.ts
@@ -936,14 +936,26 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
             /**
              * Retrieve a mindmap from its database id and open it in a wisemapping editor
              */
-            viewMindmap: async (): Promise<void> => {
+            viewMindmap: async (params: {mindmapId: string}): Promise<void> => {
 
                 if ($scope.mindmap) {
-                    $scope.notFound = "false";
+                    $scope.notFound = false;
                     $scope.openMindmap($scope.mindmap);
                 } else {
-                    $scope.notFound = "true";
-                    $scope.openMainPage();
+                    try {
+                        let m: Mindmap = await mindmapService.getMindmap(params.mindmapId)
+                        let mindMapWithRight: Mindmap = Behaviours.applicationsBehaviours.mindmap.resource(m);
+                        if (mindMapWithRight) {
+                            $scope.notFound = false;
+                            $scope.openMindmap(mindMapWithRight);
+                        } else {
+                            $scope.notFound = true;
+                            $scope.openMainPage();
+                        }
+                    } catch (e) {
+                        $scope.notFound = true;
+                        $scope.openMainPage();
+                    }
                 }
             },
             /**


### PR DESCRIPTION
## Describe your changes
Fix an error that when opening the mindmap share notification that sent us on the main page of the module with an error rather than on the view of the shared mindmap
## Checklist tests
On mindmap main page click one or more mindmap -> Click on Share -> on the share box search a user you can connect to -> give it some rights -> Share a mindmap -> then with the account of the person to whom the map was shared check if the notification from the "fil d'actualité" sent us to the mindmap editor view with the proper rights.

## Issue ticket number and link
[CO-1682](https://jira.support-ent.fr/browse/CO-1682)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)