### PR TITLE
fix(delete): #CO-1722 fix delete button displaying with no right on the map

### DIFF
--- a/src/main/resources/public/template/mindmap-list.html
+++ b/src/main/resources/public/template/mindmap-list.html
@@ -146,8 +146,8 @@
                             ng-click="display.moveMindmap = true; displayTreeMoveFolder(selectedFolderTabs[0]._id);">
                         <i18n>mindmap.folder.manage.move</i18n>
                     </button>
-                    <!--Delete mindmap, 0 folder selected, manage Right on first mindmap selected-->
-                    <resource-right name="manage" resource="selectedMindmapTabs[0]">
+                    <!--Delete mindmap, 0 folder selected, manage Right on mindmaps selected-->
+                    <resource-right name="manage" resource="selectedMindmapTabs">
                         <button ng-if="selectedFolderTabs.length == 0 " class="cell"
                                 ng-click="display.confirmDeleteMindmap = true">
                             <i18n>mindmap.folder.manage.delete</i18n>


### PR DESCRIPTION
## Describe your changes
Apply the check on the right on all the selected mindmaps and not only the first one on the list
## Checklist tests
Share a first map to a user without manage right.
Then share a second map to the same user with manage right
check with the user to whom the maps were shared if the "Supprimer" button is displayed in the toaster when selecting both maps
## Issue ticket number and link
[CO-1722](https://jira.support-ent.fr/browse/CO-1722)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)