### PR TITLE
fix(rights): #CO-1730 Fixing rights for publish and fix toaster

### DIFF
--- a/src/main/resources/public/template/mindmap-list.html
+++ b/src/main/resources/public/template/mindmap-list.html
@@ -161,7 +161,7 @@
                         </button>
                     </resource-right>
                     <!--Mindmap Publish, 0 folder selected, 1 mindmap selected, manage Rights on first mindmap selected, workflow publish-->
-                    <button workflow="mindmap.publish" ng-if="selectedMindmapTabs.length === 1 && selectedFolderTabs.length == 0"
+                    <button workflow="mindmap.publish" ng-if="selectedMindmapTabs.length === 1 && selectedFolderTabs.length == 0 && isMyMap(selectedMindmapTabs[0])"
                             library-resource="selectedMindmapTabs[0]">
                         <i18n>bpr.publish</i18n>
                     </button>

--- a/src/main/resources/public/template/mindmap-list.html
+++ b/src/main/resources/public/template/mindmap-list.html
@@ -142,7 +142,7 @@
                         </button>
                     </resource-right>
                     <!--Move mindmap, 0 folder selected, 1 mindmap selected-->
-                    <button ng-if="selectedMindmapTabs.length === 1 && selectedFolderTabs.length == 0" class="cell"
+                    <button ng-if="selectedMindmapTabs.length > 0 && selectedFolderTabs.length == 0" class="cell"
                             ng-click="display.moveMindmap = true; displayTreeMoveFolder(selectedFolderTabs[0]._id);">
                         <i18n>mindmap.folder.manage.move</i18n>
                     </button>
@@ -238,7 +238,7 @@
                     <folder-tree tree-props="folderTreeDirective"></folder-tree>
 
                     <div class="row ng-scope">
-                        <button ng-click="moveMindmap(selectedMindmapTabs[0]._id,selectedMindmapTabs[0].name); display.moveMindmap=false;"
+                        <button ng-click="moveMindmaps(selectedMindmapTabs); display.moveMindmap=false;"
                                 class="right-magnet">
                             <i18n><span class="no-style ng-scope">mindmap.folder.manage.move</span>
                             </i18n>

--- a/src/main/resources/public/ts/controllers/main.ts
+++ b/src/main/resources/public/ts/controllers/main.ts
@@ -310,8 +310,8 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
         };
 
         $scope.moveMindmaps = async function(mindmaps: Mindmap[]) {
-            mindmaps.forEach(map => {
-                $scope.moveMindmap(map._id, map.name);
+            mindmaps.forEach((mindmap: Mindmap) => {
+                $scope.moveMindmap(mindmap._id, mindmap.name);
             })
         }
 
@@ -687,8 +687,8 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
         }
 
         $scope.printPngMindmaps = function (mindmaps: Mindmap[], redirect = true) {
-            mindmaps.forEach(map => {
-                $scope.printPngMindmap(map, redirect);
+            mindmaps.forEach((mindmap: Mindmap) => {
+                $scope.printPngMindmap(mindmap, redirect);
             })
         };
 

--- a/src/main/resources/public/ts/controllers/main.ts
+++ b/src/main/resources/public/ts/controllers/main.ts
@@ -309,6 +309,12 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
             $scope.$apply();
         };
 
+        $scope.moveMindmaps = async function(maps) {
+            maps.forEach(map => {
+                $scope.moveMindmap(map._id, map.name);
+            })
+        }
+
         $scope.moveMindmap = async function (id: string, name: string): Promise<void> {
             let mindmap: MindmapFolder;
             if ($scope.selectedFoldersIdMove == FOLDER_ITEM.ID_NULL || !$scope.selectedFoldersIdMove) {

--- a/src/main/resources/public/ts/controllers/main.ts
+++ b/src/main/resources/public/ts/controllers/main.ts
@@ -309,8 +309,8 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
             $scope.$apply();
         };
 
-        $scope.moveMindmaps = async function(maps) {
-            maps.forEach(map => {
+        $scope.moveMindmaps = async function(mindmaps: Mindmap[]) {
+            mindmaps.forEach(map => {
                 $scope.moveMindmap(map._id, map.name);
             })
         }
@@ -686,6 +686,12 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
 
         }
 
+        $scope.printPngMindmaps = function (mindmaps: Mindmap[], redirect = true) {
+            mindmaps.forEach(map => {
+                $scope.printPngMindmap(map, redirect);
+            })
+        };
+
         $scope.printMindmap = function (mindmap, redirect = true) {
             if (redirect) {
                 window.open('/mindmap/print/mindmap#/print/' + mindmap._id);
@@ -933,6 +939,15 @@ export const MindmapController = ng.controller('MindmapController', ['$scope', '
             $scope.mindmap = mindmap
             $scope.display.showPanel = true;
             event.stopPropagation();
+        };
+
+        /**
+         * Verify if the selected mindmap is owned
+         * by the user logged in
+         * @param mindmap the selected mindmap
+         */
+        $scope.isMyMap = function (mindmap: Mindmap): Boolean {
+            return mindmap.owner.userId === model.me.userId;
         };
 
         /**


### PR DESCRIPTION
## Describe your changes
Fixing issue with publish right, now only owner of the mindmap can do it if they have the workflow right "publish".
Fixing toaster issue to display right button when "read-only" right is attribut.
Fixing issue with print and move buttons not displaying when selecting several mindmaps
## Checklist tests
Get logged in 2 accounts of the same structure :
Make sure to attribut "publish" workflow right to one of the account
Go to mindmap and create three
Share it to the other account. One in read-only, one in contributor and one in manager
Now with the other account, click on the mindmap to check if there is right button : 
- read-only : open, move, print
- contributor : open, move, print
- manager : open, duplicate, move, delete, properties, print, share

Also, "publish in library" only be available when the account is te owner of the mindmap and have "publish" workflow right 

To test the buttons not displaying issue, you can select multiple mindmaps with any right and make sure the buttons "move" and "print" shows.
## Issue ticket number and link
[CO-1730](https://jira.support-ent.fr/browse/CO-1730)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)