### PR TITLE
feat(share): #CO-1781 make old shared mindmap movable and duplicable (this one depending on manage right)

### DIFF
--- a/deployment/mindmap/migration/1.15.5/makeSharedMindmapDuplicable.js
+++ b/deployment/mindmap/migration/1.15.5/makeSharedMindmapDuplicable.js
@@ -1,0 +1,11 @@
+db.mindmap.updateMany({
+        shared: {
+            $elemMatch: {
+                'net-atos-entng-mindmap-controllers-MindmapController|shareResource': {$exists: true},
+                $or: [
+                    {'net-atos-entng-mindmap-controllers-MindmapController|duplicateMindmap': {$exists: false}},
+                    {'net-atos-entng-mindmap-controllers-MindmapController|duplicateMindmap': false}]
+            }
+        }
+    },
+    {$set: {"shared.$.net-atos-entng-mindmap-controllers-MindmapController|duplicateMindmap": true}});

--- a/deployment/mindmap/migration/1.15.5/makeSharedMindmapMovable.js
+++ b/deployment/mindmap/migration/1.15.5/makeSharedMindmapMovable.js
@@ -1,0 +1,10 @@
+db.mindmap.updateMany({
+        shared: {
+            $elemMatch: {
+                $or: [
+                    {'net-atos-entng-mindmap-controllers-MindmapController|changeMindmapFolder': {$exists: false}},
+                    {'net-atos-entng-mindmap-controllers-MindmapController|changeMindmapFolder': false}]
+            }
+        }
+    },
+    {$set: {"shared.$.net-atos-entng-mindmap-controllers-MindmapController|changeMindmapFolder": true}});


### PR DESCRIPTION
## Describe your changes
Faire en sorte que les Mindmaps avant [l'évolution de février/mars 2022](https://github.com/OPEN-ENT-NG/mindmap/commit/3657e1f4b694cb9a81421e0ab2cd34be6898e833) soit déplaçables et duplicables (duplicable -> si l'utilisateur possède le droit manage).

## Checklist tests
Testable sur des données antérieur au commits précédents: Déplacer et dupliquer des mindmaps correspondantes. 


## Issue ticket number and link
[Jira - CO-1781](https://jira.support-ent.fr/browse/CO-1781)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)