### PR TITLE
feat: #WB2-1057, transform editor in png to print mindmap + export fu…

### DIFF
--- a/frontend/src/features/export-modal/useExportMindmap.ts
+++ b/frontend/src/features/export-modal/useExportMindmap.ts
@@ -1,16 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { Alert, useHotToast } from "@edifice-ui/react";
-import {
-  Designer,
-  ImageExporterFactory,
-  Exporter,
-  SizeType,
-  TextExporterFactory,
-  Mindmap,
-  // @ts-ignore
-} from "@edifice-wisemapping/editor";
-import { useTranslation } from "react-i18next";
+import { exporter } from "~/services/utils";
 
 type ExportFormat = "svg" | "jpg" | "png" | "mm" | "wxml";
 type ExportGroup = "image" | "mindmap-tool";
@@ -22,13 +12,10 @@ export const useExportMindmap = ({
   mapName: string;
   onSuccess: () => void;
 }) => {
-  const { t } = useTranslation();
-
   const [submit, setSubmit] = useState<boolean>(false);
   const [exportFormat, setExportFormat] = useState<ExportFormat>("svg");
   const [exportGroup, setExportGroup] = useState<ExportGroup>("image");
   const [zoomToFit, setZoomToFit] = useState<boolean>(true);
-  const { hotToast } = useHotToast(Alert);
 
   const handleOnSubmit = (): void => {
     setSubmit(true);
@@ -58,54 +45,9 @@ export const useExportMindmap = ({
     setExportFormat(defaultFormat);
   };
 
-  const exporter = async (formatType: ExportFormat): Promise<string> => {
-    let svgElement: Element | null = null;
-    let size: SizeType;
-    let mindmap: Mindmap;
-
-    const designer: Designer = globalThis.designer;
-    // exporting from editor toolbar action
-    if (designer) {
-      // Depending on the type of export. It will require differt POST.
-      const workspace = designer.getWorkSpace();
-      svgElement = workspace.getSVGElement();
-      size = { width: window.innerWidth, height: window.innerHeight };
-      mindmap = designer.getMindmap();
-    } else {
-      hotToast.error(t("mindmap.export.failed"));
-    }
-
-    let exporter: Exporter;
-    switch (formatType) {
-      case "png":
-      case "jpg":
-      case "svg": {
-        exporter = ImageExporterFactory.create(
-          formatType,
-          svgElement,
-          size.width,
-          size.height,
-          zoomToFit,
-        );
-        break;
-      }
-      case "wxml":
-      case "mm": {
-        exporter = TextExporterFactory.create(formatType, mindmap);
-        break;
-      }
-      default: {
-        const exhaustiveCheck: never = formatType as never;
-        throw new Error(`Unhandled color case: ${exhaustiveCheck}`);
-      }
-    }
-
-    return exporter.exportAndEncode();
-  };
-
   useEffect(() => {
     if (submit) {
-      exporter(exportFormat)
+      exporter(exportFormat, zoomToFit)
         .then((url: string) => {
           // Create hidden anchor to force download ...
           const anchor: HTMLAnchorElement = document.createElement("a");

--- a/frontend/src/services/utils/index.ts
+++ b/frontend/src/services/utils/index.ts
@@ -1,0 +1,57 @@
+import {
+  Designer,
+  ImageExporterFactory,
+  Exporter,
+  SizeType,
+  TextExporterFactory,
+  Mindmap,
+  // @ts-ignore
+} from "@edifice-wisemapping/editor";
+
+type ExportFormat = "svg" | "jpg" | "png" | "mm" | "wxml";
+
+export const exporter = async (
+  formatType: ExportFormat,
+  zoomToFit: boolean,
+): Promise<string> => {
+  let svgElement: Element | null = null;
+  let size: SizeType;
+  let mindmap: Mindmap;
+
+  const designer: Designer = globalThis.designer;
+  // exporting from editor toolbar action
+  if (designer) {
+    // Depending on the type of export. It will require differt POST.
+    const workspace = designer.getWorkSpace();
+    svgElement = workspace.getSVGElement();
+    size = { width: window.innerWidth, height: window.innerHeight };
+    mindmap = designer.getMindmap();
+  }
+
+  let exporter: Exporter;
+  switch (formatType) {
+    case "png":
+    case "jpg":
+    case "svg": {
+      exporter = ImageExporterFactory.create(
+        formatType,
+        svgElement,
+        size.width,
+        size.height,
+        zoomToFit,
+      );
+      break;
+    }
+    case "wxml":
+    case "mm": {
+      exporter = TextExporterFactory.create(formatType, mindmap);
+      break;
+    }
+    default: {
+      const exhaustiveCheck: never = formatType as never;
+      throw new Error(`Unhandled color case: ${exhaustiveCheck}`);
+    }
+  }
+
+  return exporter.exportAndEncode();
+};

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -36,14 +36,15 @@ body {
   margin: 0px 20px 10px 20px;
 }
 
-@media print {
-  body, html, #root {
-    all: unset;
-    display: revert;
-  }
-
-  .no-print, .no-print *
-    {
-        display: none !important;
-    }
+@page {
+  margin: 1.5cm;
+}
+#printpng{
+  max-height: 160mm;
+  max-width: 280mm;
+}
+#printpngwrapper{
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }


### PR DESCRIPTION
## Describe your changes

Création d'un component <Image> pour afficher la carte mental centrée et prête pour l'impression (reprenant le même système que l'ancienne mindmap) 
Déplacement de la fonction `exporter` dans un fichier utils/index.ts afin de pouvoir réutiliser cette fonction. 

## Checklist tests

## Issue ticket number and link

Ticket : WB2-1057
https://edifice-community.atlassian.net/jira/software/c/projects/WB2/boards/41?modal=detail&selectedIssue=WB2-1057&assignee=712020%3A10bcae25-bc57-4d87-bad7-d00cf4320f32

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

Pas trouver de solution pour réutiliser la fonction `exporter` côté print car on récupère les même données. 

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)